### PR TITLE
Add testing workflow to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,10 +46,21 @@ that depend on them. The bootstrap file handles this.
 1. Every task starts with a GitHub issue.
 2. Create a feature branch from main: `feat/[issue-number]-[short-description]`
    or `fix/[issue-number]-[short-description]`.
-3. Commit with descriptive messages that include `Closes #N`.
-4. Push the branch and create a PR via `gh pr create` linked to the issue.
-5. Merge to main after the PR is created.
-6. Document architectural decisions as comments on the GitHub issue.
+3. Write or update tests for any code changes. Run `composer test` to verify
+   nothing is broken before committing. Mock external data (Strava API responses,
+   HTTP calls) — never hit real APIs in tests.
+4. Commit with descriptive messages that include `Closes #N`.
+5. Push the branch and create a PR via `gh pr create` linked to the issue.
+6. Merge to main after the PR is created.
+7. Document architectural decisions as comments on the GitHub issue.
+
+### Testing
+
+- Unit tests live in `tests/Unit/` — pure logic, no WordPress needed.
+- Integration tests live in `tests/Integration/` — require the WP test suite.
+- Test fixtures (sample API responses) live in `tests/fixtures/`.
+- Always mock HTTP responses. Never call the real Strava API.
+- Run `composer test` before every commit to catch regressions.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary
- Add testing as step 3 in the workflow (before committing)
- Add Testing section with unit/integration test conventions
- Require mocked HTTP — never hit real Strava API in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)