### PR TITLE
Add community docs — README, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CHANGELOG

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -11,5 +11,8 @@
 /vendor/
 /phpcs.xml.dist
 /CLAUDE.md
+/CHANGELOG.md
 /CONTRIBUTING.md
 /CODE_OF_CONDUCT.md
+/SECURITY.md
+/README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-03-15
+
+### Added
+- Plugin bootstrap with WPGraphQL dependency check and cron scheduling
+- Strava API client with OAuth token refresh and rate limiting
+- Transient caching with configurable TTL and photo enrichment
+- Google polyline decoder and server-side SVG route map generator
+- WPGraphQL schema: StravaActivity type and stravaActivities query with type filter
+- Admin settings page: credentials, SVG customization, display units, sync frequency
+- Getting Started documentation page with setup guide and code examples
+- Preview page with live activity cards and demo data
+- Optional AES-256-CBC at-rest credential encryption
+- WordPress.org readme.txt with Third-Party Service disclosure
+- GitHub Actions workflow for WordPress.org SVN deployment
+- Dependabot for Composer and GitHub Actions updates
+- WPCS 3.0 linting via composer lint

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project maintainers
+at [conduct@shawnazar.me](mailto:conduct@shawnazar.me). All complaints will be
+reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/), version 2.1,
+available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to GraphQL Strava Activities
+
+Thank you for your interest in contributing! This guide will help you get started.
+
+## Reporting Bugs
+
+1. Search [existing issues](https://github.com/shawnazar/wp-graphql-strava/issues) to avoid duplicates.
+2. Open a new issue with:
+   - WordPress, PHP, and WPGraphQL versions
+   - Steps to reproduce
+   - Expected vs actual behaviour
+   - Any error messages from `debug.log`
+
+## Suggesting Features
+
+Open a [GitHub issue](https://github.com/shawnazar/wp-graphql-strava/issues/new) describing:
+- What you'd like to see
+- Why it would be useful
+- Any implementation ideas
+
+## Development Setup
+
+1. Fork and clone the repository
+2. Mount the plugin in a local WordPress environment:
+   ```bash
+   cd wp-content/plugins/
+   git clone https://github.com/YOUR-USERNAME/wp-graphql-strava.git graphql-strava-activities
+   ```
+3. Install dev dependencies:
+   ```bash
+   composer install
+   ```
+4. Install and activate [WPGraphQL](https://www.wpgraphql.com/) in your WordPress instance.
+
+## Submitting a Pull Request
+
+1. **Create a GitHub issue first** — every PR should reference an issue.
+2. **Branch from main:**
+   - `feat/[issue-number]-[short-description]` for new features
+   - `fix/[issue-number]-[short-description]` for bug fixes
+3. **Follow the code style:**
+   - WordPress coding standards (run `composer lint` to check)
+   - `declare(strict_types=1)` in every PHP file
+   - PHPDoc on every function
+   - Text domain: `graphql-strava-activities`
+4. **Write or update tests** for your changes.
+5. **Commit with descriptive messages** that include `Closes #N`.
+6. **Push and open a PR** via `gh pr create` or the GitHub web UI.
+
+## Code Style
+
+This project uses [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/) enforced via PHP_CodeSniffer:
+
+```bash
+composer lint         # Check for violations
+composer lint:fix     # Auto-fix what's possible
+```
+
+## Security
+
+- All user input must be sanitized (`sanitize_*` functions)
+- All output must be escaped (`esc_*` functions)
+- All forms must use nonces (`wp_nonce_field` / `check_admin_referer`)
+- Admin pages must check `current_user_can('manage_options')`
+- Sensitive options must use `wpgraphql_strava_get_option()` / `wpgraphql_strava_update_option()`
+- Never commit credentials or API keys
+
+## Questions?
+
+Open an issue — happy to help!

--- a/README.md
+++ b/README.md
@@ -1,0 +1,115 @@
+# GraphQL Strava Activities
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![PHP 8.0+](https://img.shields.io/badge/PHP-8.0%2B-8892BF.svg)](https://www.php.net/)
+[![WordPress 6.0+](https://img.shields.io/badge/WordPress-6.0%2B-21759B.svg)](https://wordpress.org/)
+[![WPGraphQL 2.0+](https://img.shields.io/badge/WPGraphQL-2.0%2B-4B32C3.svg)](https://www.wpgraphql.com/)
+
+A WordPress plugin that extends [WPGraphQL](https://www.wpgraphql.com/) with Strava activity data, server-side SVG route maps, and activity photos — no JavaScript map libraries required.
+
+## Features
+
+- **GraphQL API** — Query Strava activities with filtering by type and count
+- **SVG Route Maps** — Server-rendered inline SVG from Strava polyline data
+- **Activity Photos** — Primary photo fetching for your activities
+- **Caching** — Transient-based with configurable TTL and sync frequency
+- **Credential Encryption** — Optional AES-256-CBC at-rest encryption
+- **Extensible** — Filters for cache TTL, SVG appearance, activity types, and more
+
+## Requirements
+
+- PHP 8.0+
+- WordPress 6.0+
+- [WPGraphQL](https://www.wpgraphql.com/) 2.0+ (required — plugin will not activate without it)
+
+## Installation
+
+### From WordPress Admin
+
+1. Install and activate [WPGraphQL](https://www.wpgraphql.com/)
+2. Upload the plugin zip via **Plugins → Add New → Upload Plugin**
+3. Activate and go to **Strava → Getting Started** for setup instructions
+
+### Manual
+
+```bash
+cd wp-content/plugins/
+git clone https://github.com/shawnazar/wp-graphql-strava.git graphql-strava-activities
+```
+
+Activate in WordPress, then visit **Strava** in the admin menu.
+
+## Quick Start
+
+1. Create a Strava API application at [strava.com/settings/api](https://www.strava.com/settings/api)
+2. Enter your credentials in **Strava → Settings**
+3. Click **Resync Activities**
+4. Query via GraphQL:
+
+```graphql
+{
+  stravaActivities(first: 10, type: "Ride") {
+    title
+    distance
+    duration
+    date
+    svgMap
+    stravaUrl
+    photoUrl
+    type
+    unit
+  }
+}
+```
+
+## Filters
+
+All filters use the `wpgraphql_strava_` prefix:
+
+| Filter | Default | Description |
+|---|---|---|
+| `wpgraphql_strava_cache_ttl` | `43200` (12h) | Cache duration in seconds |
+| `wpgraphql_strava_svg_color` | `#0d9488` | SVG stroke colour |
+| `wpgraphql_strava_svg_stroke_width` | `2.5` | SVG stroke width |
+| `wpgraphql_strava_svg_attributes` | `[]` | Extra SVG element attributes |
+| `wpgraphql_strava_activities` | — | Filter activities before caching |
+| `wpgraphql_strava_activity_types` | `[]` (all) | Whitelist of allowed types |
+
+```php
+// Example: only show rides and runs
+add_filter( 'wpgraphql_strava_activity_types', function () {
+    return [ 'Ride', 'Run' ];
+} );
+```
+
+## Credential Encryption (Optional)
+
+Add to `wp-config.php`:
+
+```php
+define( 'GRAPHQL_STRAVA_ENCRYPTION_KEY', 'your-64-char-hex-key' );
+```
+
+Generate a key: `wp eval "echo bin2hex(random_bytes(32));"`
+
+## Development
+
+```bash
+composer install      # Install dev dependencies (WPCS)
+composer lint         # Check coding standards
+composer lint:fix     # Auto-fix violations
+```
+
+No build step — pure PHP.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on reporting bugs, suggesting features, and submitting pull requests.
+
+## Security
+
+To report a vulnerability, see [SECURITY.md](SECURITY.md). Please do **not** use public GitHub issues for security reports.
+
+## License
+
+[MIT](LICENSE) — Copyright (c) 2026 Shawn Azar

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 1.0.x   | Yes       |
+
+## Reporting a Problem
+
+If you discover a security issue, please report it privately. **Do not** open a public GitHub issue.
+
+**Email:** [security@shawnazar.me](mailto:security@shawnazar.me)
+
+Include:
+- Description of the issue
+- Steps to reproduce
+- Affected versions
+- Any potential impact
+
+You should receive an acknowledgement within 48 hours. We aim to release a fix within 7 days of confirmation.
+
+## Scope
+
+This policy covers the GraphQL Strava Activities WordPress plugin code in this repository. Issues with the Strava API itself should be reported to [Strava](https://www.strava.com/legal/security).
+
+## Credential Storage
+
+- API tokens are stored in the WordPress `wp_options` table
+- Optional AES-256-CBC encryption is available via the `GRAPHQL_STRAVA_ENCRYPTION_KEY` constant in `wp-config.php`
+- All credentials are sanitized before storage and escaped on output
+
+## Best Practices for Users
+
+- Keep WordPress, WPGraphQL, and this plugin up to date
+- Use the optional encryption feature for stored credentials
+- Restrict access to your WordPress admin dashboard
+- Use HTTPS on your WordPress site

--- a/readme.txt
+++ b/readme.txt
@@ -33,21 +33,19 @@ GraphQL Strava Activities brings your Strava activities into your headless WordP
 
 **Example GraphQL Query:**
 
-`
-{
-  stravaActivities(first: 10, type: "Ride") {
-    title
-    distance
-    duration
-    date
-    svgMap
-    stravaUrl
-    photoUrl
-    type
-    unit
-  }
-}
-`
+    {
+      stravaActivities(first: 10, type: "Ride") {
+        title
+        distance
+        duration
+        date
+        svgMap
+        stravaUrl
+        photoUrl
+        type
+        unit
+      }
+    }
 
 == Third-Party Service ==
 


### PR DESCRIPTION
## Summary
- **README.md** — GitHub-facing with badges, features, quick start, filters table, dev setup
- **CONTRIBUTING.md** — Bug reports, PR workflow, code style, security guidelines
- **SECURITY.md** — Private reporting instructions, credential storage docs
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1
- **CHANGELOG.md** — Keep a Changelog format with v1.0.0 entry
- Fix readme.txt code block to use 4-space indent (WordPress format)
- Update .distignore to exclude new docs from WordPress.org zip

Closes #7
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)