### PR TITLE
Add issue/PR templates, labels, auto-delete branches

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug Report
+description: Report a bug with the plugin
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug! Please fill out the details below.
+
+  - type: input
+    id: wp-version
+    attributes:
+      label: WordPress Version
+      placeholder: "6.7"
+    validations:
+      required: true
+
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP Version
+      placeholder: "8.2"
+    validations:
+      required: true
+
+  - type: input
+    id: wpgraphql-version
+    attributes:
+      label: WPGraphQL Version
+      placeholder: "2.1.0"
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin Version
+      placeholder: "1.0.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this?
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error Logs
+      description: Any relevant errors from `debug.log` or browser console.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Help
+    url: https://github.com/shawnazar/wp-graphql-strava/discussions
+    about: Ask questions and get help from the community. Please don't open issues for general questions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea? We'd love to hear it!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? What's the use case?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like this to work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any workarounds or alternative approaches you've thought of?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Screenshots, links, or anything else that helps explain.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What does this PR do? Keep it brief. -->
+
+## Related Issue
+
+<!-- Link the GitHub issue this PR addresses. -->
+Closes #
+
+## Changes
+
+-
+
+## Checklist
+
+- [ ] Code follows WordPress coding standards (`composer lint` passes)
+- [ ] Tests added/updated for changes (`composer test` passes)
+- [ ] `CHANGELOG.md` updated under `[Unreleased]`
+- [ ] All strings use text domain `graphql-strava-activities`
+- [ ] Sensitive data uses `wpgraphql_strava_get_option()` / `wpgraphql_strava_update_option()`


### PR DESCRIPTION
## Summary
- Bug report issue template (YAML form with version fields)
- Feature request issue template (problem/solution format)
- Config redirecting questions to GitHub Discussions
- PR template with checklist (lint, tests, changelog, text domain, encryption helpers)
- Labels applied to all open issues
- Auto-delete branches on merge enabled via API
- `security` and `breaking change` labels created

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)