### PR TITLE
Fix test bootstrap — define ABSPATH so plugin files don't exit

### DIFF
--- a/tests/Integration/CacheTest.php
+++ b/tests/Integration/CacheTest.php
@@ -108,11 +108,6 @@ class CacheTest extends TestCase {
             }
         );
 
-        // Define HOUR_IN_SECONDS if not defined.
-        if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
-            define( 'HOUR_IN_SECONDS', 3600 );
-        }
-
         // Load modules in order.
         require_once dirname( __DIR__, 2 ) . '/includes/polyline.php';
         if ( ! function_exists( 'wpgraphql_strava_polyline_to_svg' ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,12 +2,22 @@
 /**
  * PHPUnit bootstrap file.
  *
- * Loads Brain\Monkey for unit tests. Integration tests requiring the
- * full WordPress test suite should be run separately with WP_TESTS_DIR set.
+ * Defines ABSPATH so plugin files don't exit, then loads
+ * Composer autoload for Brain\Monkey and test dependencies.
  *
  * @package WPGraphQL\Strava
  */
 
 declare(strict_types=1);
+
+// Define ABSPATH so plugin files don't call exit.
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+// Define WordPress time constants used by the plugin.
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+    define( 'HOUR_IN_SECONDS', 3600 );
+}
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- Define `ABSPATH` in `tests/bootstrap.php` so plugin files don't call `exit()`
- Move `HOUR_IN_SECONDS` constant to bootstrap (remove duplicate from CacheTest)
- All 33 tests now pass: `OK (33 tests, 81 assertions)`

## Test plan
- [x] `composer test` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)