### PR TITLE
Add PHPStan level 5 static analysis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Run linter
         run: composer lint
 
+      - name: Run static analysis
+        run: composer analyse
+
       - name: Run tests
         run: composer test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `composer test`, `composer test:unit`, `composer test:integration` scripts
 - GrumPHP pre-commit hooks — lint and tests run automatically on every commit
 - SUPPORT.md with help channels and in-plugin docs reference
+- PHPStan level 5 static analysis with WordPress extension
+- `composer analyse` script and PHPStan in GrumPHP pre-commit
 - GitHub Release automation — creates release with zip on tag push
 - Repo topics, discussion categories, required PR approvals
 - Sample Strava API response fixture for test mocking

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
     "yoast/phpunit-polyfills": "^2.0",
     "wp-phpunit/wp-phpunit": "^6.0",
     "brain/monkey": "^2.6",
-    "phpro/grumphp": "^2.19"
+    "phpro/grumphp": "^2.19",
+    "phpstan/phpstan": "^2.1",
+    "szepeviktor/phpstan-wordpress": "^2.0"
   },
   "autoload-dev": {
     "psr-4": {
@@ -38,6 +40,7 @@
     "lint:fix": "phpcbf",
     "test": "phpunit",
     "test:unit": "phpunit --testsuite unit",
-    "test:integration": "phpunit --testsuite integration"
+    "test:integration": "phpunit --testsuite integration",
+    "analyse": "phpstan analyse"
   }
 }

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -11,6 +11,11 @@ grumphp:
       triggered_by:
         - php
 
+    phpstan:
+      configuration: phpstan.neon.dist
+      triggered_by:
+        - php
+
     phpunit:
       config_file: phpunit.xml.dist
       always_execute: true

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -184,7 +184,7 @@ function wpgraphql_strava_register_settings(): void {
 	add_settings_section(
 		'wpgraphql_strava_display',
 		__( 'Display', 'graphql-strava-activities' ),
-		null,
+		'__return_null',
 		'wpgraphql-strava'
 	);
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,6 +6,9 @@
     <file>wp-graphql-strava.php</file>
     <file>includes/</file>
 
+    <!-- Exclude stubs and tests from scanning -->
+    <exclude-pattern>stubs/</exclude-pattern>
+
     <!-- Show progress and sniff codes in all reports -->
     <arg value="ps"/>
     <arg name="colors"/>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,23 @@
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+
+parameters:
+    level: 5
+    paths:
+        - wp-graphql-strava.php
+        - includes/
+    excludePaths:
+        - vendor/
+        - tests/
+    bootstrapFiles:
+        - vendor/autoload.php
+    stubFiles:
+        - stubs/wpgraphql.php
+    treatPhpDocTypesAsCertain: false
+    dynamicConstantNames:
+        - GRAPHQL_STRAVA_ENCRYPTION_KEY
+    ignoreErrors:
+        - '#PHPDoc tag @var does not specify variable name#'
+        - '#Constant GRAPHQL_STRAVA_ENCRYPTION_KEY not found#'
+    scanFiles:
+        - stubs/wpgraphql.php

--- a/stubs/wpgraphql.php
+++ b/stubs/wpgraphql.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * WPGraphQL function stubs for PHPStan.
+ *
+ * @package WPGraphQL\Strava
+ */
+
+/**
+ * @param string               $type_name Type name.
+ * @param array<string, mixed> $config    Type configuration.
+ * @return void
+ */
+function register_graphql_object_type( string $type_name, array $config ): void {}
+
+/**
+ * @param string               $type_name  Type to extend.
+ * @param string               $field_name Field name.
+ * @param array<string, mixed> $config     Field configuration.
+ * @return void
+ */
+function register_graphql_field( string $type_name, string $field_name, array $config ): void {}


### PR DESCRIPTION
## Summary
- PHPStan level 5 with `szepeviktor/phpstan-wordpress` extension
- WPGraphQL function stubs for static analysis
- `composer analyse` script
- Added to GrumPHP pre-commit (3 tasks: phpcs, phpstan, phpunit)
- Added to CI workflow (lint → analyse → test)
- Fixed `null` callback in `add_settings_section` (admin.php)
- 0 errors at level 5

Closes #36

## Test plan
- [x] `composer lint` passes
- [x] `composer analyse` passes (0 errors)
- [x] `composer test` passes (33 tests, 81 assertions)
- [x] GrumPHP pre-commit passed all 3 tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)