### PR TITLE
Fix route toggle — force resync on change, fix settings page slug

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -249,7 +249,7 @@ function wpgraphql_strava_register_settings(): void {
 		'wpgraphql_strava_include_no_route',
 		__( 'Activities Without Routes', 'graphql-strava-activities' ),
 		'wpgraphql_strava_render_no_route_field',
-		'wpgraphql-strava',
+		'wpgraphql-strava-settings',
 		'wpgraphql_strava_display'
 	);
 }
@@ -358,7 +358,7 @@ function wpgraphql_strava_render_no_route_field(): void {
 		<?php esc_html_e( 'Include indoor and GPS-less activities (yoga, weight training, treadmill, etc.)', 'graphql-strava-activities' ); ?>
 	</label>
 	<p class="description">
-		<?php esc_html_e( 'When enabled, activities without GPS routes will appear with an empty svgMap field.', 'graphql-strava-activities' ); ?>
+		<?php esc_html_e( 'When enabled, activities without GPS routes will appear with an empty svgMap field. Changing this setting triggers a forced resync.', 'graphql-strava-activities' ); ?>
 	</p>
 	<?php
 }

--- a/wp-graphql-strava.php
+++ b/wp-graphql-strava.php
@@ -149,6 +149,26 @@ function wpgraphql_strava_reschedule_cron( $old_value, $new_value ): void {
 add_action( 'update_option_wpgraphql_strava_cron_schedule', 'wpgraphql_strava_reschedule_cron', 10, 2 );
 
 /**
+ * Force a cache refresh when the "include no route" toggle changes.
+ *
+ * The cached activities were built with the previous setting, so they
+ * must be rebuilt to include or exclude GPS-less activities.
+ *
+ * @param mixed $old_value Previous value.
+ * @param mixed $new_value New value.
+ * @return void
+ */
+function wpgraphql_strava_flush_on_route_toggle( $old_value, $new_value ): void {
+	if ( $old_value === $new_value ) {
+		return;
+	}
+
+	delete_transient( 'wpgraphql_strava_activities' );
+}
+
+add_action( 'update_option_wpgraphql_strava_include_no_route', 'wpgraphql_strava_flush_on_route_toggle', 10, 2 );
+
+/**
  * On deactivation: clear the cron event and flush cache.
  *
  * @return void


### PR DESCRIPTION
## Summary
- **Bug fix**: The "Activities Without Routes" checkbox wasn't showing on the Settings page — it was registered with the old page slug `wpgraphql-strava` instead of `wpgraphql-strava-settings`
- **Force resync**: Cache is flushed when the toggle changes so the next page load rebuilds with the new setting
- **User feedback**: Description text now tells the user "Changing this setting triggers a forced resync"

## Test plan
- [x] `composer lint` passes
- [x] `composer analyse` passes
- [x] `composer test` passes (34 tests, 84 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)