### PR TITLE
Add toggle to include private activities

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -252,6 +252,24 @@ function wpgraphql_strava_register_settings(): void {
 		'wpgraphql-strava-settings',
 		'wpgraphql_strava_display'
 	);
+
+	register_setting(
+		'wpgraphql_strava_settings',
+		'wpgraphql_strava_include_private',
+		[
+			'type'              => 'boolean',
+			'sanitize_callback' => 'rest_sanitize_boolean',
+			'default'           => false,
+		]
+	);
+
+	add_settings_field(
+		'wpgraphql_strava_include_private',
+		__( 'Private Activities', 'graphql-strava-activities' ),
+		'wpgraphql_strava_render_private_field',
+		'wpgraphql-strava-settings',
+		'wpgraphql_strava_display'
+	);
 }
 
 // ------------------------------------------------------------------
@@ -359,6 +377,24 @@ function wpgraphql_strava_render_no_route_field(): void {
 	</label>
 	<p class="description">
 		<?php esc_html_e( 'When enabled, activities without GPS routes will appear with an empty svgMap field. Changing this setting triggers a forced resync.', 'graphql-strava-activities' ); ?>
+	</p>
+	<?php
+}
+
+/**
+ * Render the "include private activities" checkbox.
+ *
+ * @return void
+ */
+function wpgraphql_strava_render_private_field(): void {
+	$value = (bool) get_option( 'wpgraphql_strava_include_private', false );
+	?>
+	<label>
+		<input type="checkbox" name="wpgraphql_strava_include_private" value="1" <?php checked( $value ); ?> />
+		<?php esc_html_e( 'Include private activities in GraphQL results', 'graphql-strava-activities' ); ?>
+	</label>
+	<p class="description" style="color: #d63638;">
+		<?php esc_html_e( 'Warning: If your GraphQL endpoint is publicly accessible, enabling this will expose your private Strava activities. Changing this setting triggers a forced resync.', 'graphql-strava-activities' ); ?>
 	</p>
 	<?php
 }

--- a/includes/cache.php
+++ b/includes/cache.php
@@ -126,6 +126,13 @@ function wpgraphql_strava_process_activities( array $raw_activities ): array {
 			continue;
 		}
 
+		// Skip private activities unless the toggle is on.
+		$is_private      = ! empty( $activity['private'] );
+		$include_private = (bool) get_option( 'wpgraphql_strava_include_private', false );
+		if ( $is_private && ! $include_private ) {
+			continue;
+		}
+
 		// Filter by activity type when a whitelist is set.
 		$type = $activity['type'] ?? 'Workout';
 		if ( ! empty( $allowed_types ) && ! in_array( $type, $allowed_types, true ) ) {

--- a/wp-graphql-strava.php
+++ b/wp-graphql-strava.php
@@ -202,6 +202,7 @@ function wpgraphql_strava_flush_on_route_toggle( $old_value, $new_value ): void 
 }
 
 add_action( 'update_option_wpgraphql_strava_include_no_route', 'wpgraphql_strava_flush_on_route_toggle', 10, 2 );
+add_action( 'update_option_wpgraphql_strava_include_private', 'wpgraphql_strava_flush_on_route_toggle', 10, 2 );
 
 /**
  * On deactivation: clear the cron event and flush cache.


### PR DESCRIPTION
## Summary
- Checkbox toggle in Display settings: "Include private activities"
- Default off — only public activities shown
- Red warning text about exposing private data via public GraphQL endpoint
- Cache flushed on toggle change (reuses existing flush hook)

Closes #46

## Test plan
- [x] All checks pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)