### PR TITLE
Add paginated Activities page to browse synced data

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -56,6 +56,15 @@ function wpgraphql_strava_add_admin_menu(): void {
 
 	add_submenu_page(
 		'wpgraphql-strava',
+		__( 'Activities', 'graphql-strava-activities' ),
+		__( 'Activities', 'graphql-strava-activities' ),
+		'manage_options',
+		'wpgraphql-strava-activities',
+		'wpgraphql_strava_render_activities_page'
+	);
+
+	add_submenu_page(
+		'wpgraphql-strava',
 		__( 'Preview', 'graphql-strava-activities' ),
 		__( 'Preview', 'graphql-strava-activities' ),
 		'manage_options',
@@ -506,6 +515,40 @@ function wpgraphql_strava_handle_resync(): void {
 }
 
 // ------------------------------------------------------------------
+// Shared footer.
+// ------------------------------------------------------------------
+
+/**
+ * Render the plugin footer with author links.
+ *
+ * @return void
+ */
+function wpgraphql_strava_render_admin_footer(): void {
+	?>
+	<hr />
+	<div style="display: flex; gap: 16px; flex-wrap: wrap; font-size: 13px; color: #646970; margin-top: 8px;">
+		<span>
+			<?php
+			printf(
+				/* translators: %s: Author website link */
+				esc_html__( 'Built by %s', 'graphql-strava-activities' ),
+				'<a href="https://shawnazar.me" target="_blank" rel="noopener noreferrer">Shawn Azar</a>'
+			);
+			?>
+		</span>
+		<span>&middot;</span>
+		<a href="https://www.buymeacoffee.com/shawnazar" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Buy Me a Coffee', 'graphql-strava-activities' ); ?></a>
+		<span>&middot;</span>
+		<a href="https://github.com/shawnazar/wp-graphql-strava" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'GitHub', 'graphql-strava-activities' ); ?></a>
+		<span>&middot;</span>
+		<a href="https://github.com/shawnazar/wp-graphql-strava/issues" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Report an Issue', 'graphql-strava-activities' ); ?></a>
+		<span>&middot;</span>
+		<a href="https://github.com/shawnazar/wp-graphql-strava/discussions" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Discussions', 'graphql-strava-activities' ); ?></a>
+	</div>
+	<?php
+}
+
+// ------------------------------------------------------------------
 // Page renderer.
 // ------------------------------------------------------------------
 
@@ -623,28 +666,7 @@ function wpgraphql_strava_render_admin_page(): void {
 			<?php esc_html_e( 'Each sync: 1 list call + up to 5 detail calls for photos, with a 200 ms delay between detail calls. Manual resyncs count toward the same limits.', 'graphql-strava-activities' ); ?>
 		</p>
 
-		<hr />
-
-		<!-- Plugin Info -->
-		<div style="display: flex; gap: 16px; flex-wrap: wrap; font-size: 13px; color: #646970; margin-top: 8px;">
-			<span>
-				<?php
-				printf(
-					/* translators: %s: Author website link */
-					esc_html__( 'Built by %s', 'graphql-strava-activities' ),
-					'<a href="https://shawnazar.me" target="_blank" rel="noopener noreferrer">Shawn Azar</a>'
-				);
-				?>
-			</span>
-			<span>&middot;</span>
-			<a href="https://www.buymeacoffee.com/shawnazar" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Buy Me a Coffee', 'graphql-strava-activities' ); ?></a>
-			<span>&middot;</span>
-			<a href="https://github.com/shawnazar/wp-graphql-strava" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'GitHub', 'graphql-strava-activities' ); ?></a>
-			<span>&middot;</span>
-			<a href="https://github.com/shawnazar/wp-graphql-strava/issues" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Report an Issue', 'graphql-strava-activities' ); ?></a>
-			<span>&middot;</span>
-			<a href="https://github.com/shawnazar/wp-graphql-strava/discussions" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Discussions', 'graphql-strava-activities' ); ?></a>
-		</div>
+		<?php wpgraphql_strava_render_admin_footer(); ?>
 	</div>
 	<?php
 }
@@ -914,6 +936,8 @@ function wpgraphql_strava_render_guide_page(): void {
 				</p>
 			</div>
 
+			<?php wpgraphql_strava_render_admin_footer(); ?>
+
 		</div>
 	</div>
 	<?php
@@ -1171,7 +1195,52 @@ function wpgraphql_strava_render_preview_page(): void {
 				</div>
 			<?php endif; ?>
 
+			<?php wpgraphql_strava_render_admin_footer(); ?>
+
 		</div>
+	</div>
+	<?php
+}
+
+// ------------------------------------------------------------------
+// Activities list page.
+// ------------------------------------------------------------------
+
+/**
+ * Render the Activities admin page with WP_List_Table.
+ *
+ * @return void
+ */
+function wpgraphql_strava_render_activities_page(): void {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	$table = new WPGRAPHQL_Strava_Activities_List_Table();
+	$table->prepare_items();
+
+	$total = $table->get_pagination_arg( 'total_items' );
+	?>
+	<div class="wrap">
+		<h1 class="wp-heading-inline"><?php esc_html_e( 'Strava Activities', 'graphql-strava-activities' ); ?></h1>
+		<span style="color:#646970;margin-left:8px;">
+			<?php
+			printf(
+				/* translators: %d: Total number of cached activities */
+				esc_html__( '%d cached', 'graphql-strava-activities' ),
+				(int) $total
+			);
+			?>
+		</span>
+
+		<hr class="wp-header-end" />
+
+		<form method="get">
+			<input type="hidden" name="page" value="wpgraphql-strava-activities" />
+			<?php $table->display(); ?>
+		</form>
+
+		<?php wpgraphql_strava_render_admin_footer(); ?>
 	</div>
 	<?php
 }

--- a/includes/class-wpgraphql-strava-activities-list-table.php
+++ b/includes/class-wpgraphql-strava-activities-list-table.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Activities list table for the admin.
+ *
+ * Extends WP_List_Table to display cached Strava activities
+ * with pagination, sorting, and type filtering.
+ *
+ * @package WPGraphQL\Strava
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WP_List_Table' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+/**
+ * Strava Activities List Table.
+ */
+class WPGRAPHQL_Strava_Activities_List_Table extends WP_List_Table {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct(
+			[
+				'singular' => 'strava-activity',
+				'plural'   => 'strava-activities',
+				'ajax'     => false,
+			]
+		);
+	}
+
+	/**
+	 * Define table columns.
+	 *
+	 * @return array<string, string>
+	 */
+	public function get_columns(): array {
+		return [
+			'title'    => __( 'Title', 'graphql-strava-activities' ),
+			'type'     => __( 'Type', 'graphql-strava-activities' ),
+			'distance' => __( 'Distance', 'graphql-strava-activities' ),
+			'duration' => __( 'Duration', 'graphql-strava-activities' ),
+			'date'     => __( 'Date', 'graphql-strava-activities' ),
+			'route'    => __( 'Route', 'graphql-strava-activities' ),
+			'photo'    => __( 'Photo', 'graphql-strava-activities' ),
+			'strava'   => __( 'Strava', 'graphql-strava-activities' ),
+		];
+	}
+
+	/**
+	 * Define sortable columns.
+	 *
+	 * @return array<string, array<int, string|bool>>
+	 */
+	public function get_sortable_columns(): array {
+		return [
+			'title'    => [ 'title', false ],
+			'type'     => [ 'type', false ],
+			'distance' => [ 'distance', false ],
+			'date'     => [ 'date', true ],
+		];
+	}
+
+	/**
+	 * Prepare items for display.
+	 *
+	 * @return void
+	 */
+	public function prepare_items(): void {
+		$activities = wpgraphql_strava_get_cached_activities( 0 );
+
+		// Type filter.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter.
+		$type_filter = isset( $_GET['activity_type'] ) ? sanitize_text_field( wp_unslash( $_GET['activity_type'] ) ) : '';
+		if ( ! empty( $type_filter ) ) {
+			$activities = array_values(
+				array_filter(
+					$activities,
+					static fn( array $a ): bool => ( $a['type'] ?? '' ) === $type_filter
+				)
+			);
+		}
+
+		// Sorting.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only sort params.
+		$orderby = isset( $_GET['orderby'] ) ? sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) : 'date';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$order = isset( $_GET['order'] ) ? sanitize_text_field( wp_unslash( $_GET['order'] ) ) : 'desc';
+
+		usort(
+			$activities,
+			static function ( array $a, array $b ) use ( $orderby, $order ): int {
+				$val_a = $a[ $orderby ] ?? '';
+				$val_b = $b[ $orderby ] ?? '';
+
+				if ( is_numeric( $val_a ) && is_numeric( $val_b ) ) {
+					$result = (float) $val_a <=> (float) $val_b;
+				} else {
+					$result = strnatcasecmp( (string) $val_a, (string) $val_b );
+				}
+
+				return 'asc' === $order ? $result : -$result;
+			}
+		);
+
+		// Pagination.
+		$per_page    = 20;
+		$total_items = count( $activities );
+		$current     = $this->get_pagenum();
+		$offset      = ( $current - 1 ) * $per_page;
+
+		$this->items = array_slice( $activities, $offset, $per_page );
+
+		$this->set_pagination_args(
+			[
+				'total_items' => $total_items,
+				'per_page'    => $per_page,
+				'total_pages' => (int) ceil( $total_items / $per_page ),
+			]
+		);
+
+		$this->_column_headers = [
+			$this->get_columns(),
+			[],
+			$this->get_sortable_columns(),
+		];
+	}
+
+	/**
+	 * Default column renderer.
+	 *
+	 * @param array<string, mixed> $item        Activity data.
+	 * @param string               $column_name Column key.
+	 * @return string Cell content.
+	 */
+	public function column_default( $item, $column_name ): string {
+		return esc_html( (string) ( $item[ $column_name ] ?? '' ) );
+	}
+
+	/**
+	 * Title column.
+	 *
+	 * @param array<string, mixed> $item Activity data.
+	 * @return string Cell content.
+	 */
+	public function column_title( array $item ): string {
+		$title = esc_html( $item['title'] ?? '' );
+
+		if ( ! empty( $item['isPrivate'] ) ) {
+			$title .= ' <span style="background:#fef3c7;color:#92400e;font-size:11px;padding:1px 6px;border-radius:9999px;">' . esc_html__( 'Private', 'graphql-strava-activities' ) . '</span>';
+		}
+
+		return $title;
+	}
+
+	/**
+	 * Distance column — includes unit.
+	 *
+	 * @param array<string, mixed> $item Activity data.
+	 * @return string Cell content.
+	 */
+	public function column_distance( array $item ): string {
+		return esc_html( (string) ( $item['distance'] ?? '0' ) ) . ' ' . esc_html( $item['unit'] ?? 'mi' );
+	}
+
+	/**
+	 * Date column — formatted.
+	 *
+	 * @param array<string, mixed> $item Activity data.
+	 * @return string Cell content.
+	 */
+	public function column_date( array $item ): string {
+		if ( empty( $item['date'] ) ) {
+			return '—';
+		}
+		$ts = strtotime( $item['date'] );
+		return $ts ? esc_html( wp_date( 'M j, Y g:i A', $ts ) ) : esc_html( $item['date'] );
+	}
+
+	/**
+	 * Route column — shows check or dash.
+	 *
+	 * @param array<string, mixed> $item Activity data.
+	 * @return string Cell content.
+	 */
+	public function column_route( array $item ): string {
+		return ! empty( $item['svgMap'] )
+			? '<span style="color:#16a34a;" title="' . esc_attr__( 'Has route map', 'graphql-strava-activities' ) . '">&#10003;</span>'
+			: '<span style="color:#9ca3af;">—</span>';
+	}
+
+	/**
+	 * Photo column — shows thumbnail or dash.
+	 *
+	 * @param array<string, mixed> $item Activity data.
+	 * @return string Cell content.
+	 */
+	public function column_photo( array $item ): string {
+		if ( empty( $item['photoUrl'] ) ) {
+			return '<span style="color:#9ca3af;">—</span>';
+		}
+
+		return '<img src="' . esc_url( $item['photoUrl'] ) . '" alt="' . esc_attr__( 'Activity photo', 'graphql-strava-activities' ) . '" style="width:40px;height:40px;object-fit:cover;border-radius:4px;" />';
+	}
+
+	/**
+	 * Strava link column.
+	 *
+	 * @param array<string, mixed> $item Activity data.
+	 * @return string Cell content.
+	 */
+	public function column_strava( array $item ): string {
+		if ( empty( $item['stravaUrl'] ) ) {
+			return '—';
+		}
+
+		return '<a href="' . esc_url( $item['stravaUrl'] ) . '" target="_blank" rel="noopener noreferrer" style="color:#FC5200;font-weight:bold;text-decoration:none;">' . esc_html__( 'View', 'graphql-strava-activities' ) . ' &rarr;</a>';
+	}
+
+	/**
+	 * Display when no items found.
+	 *
+	 * @return void
+	 */
+	public function no_items(): void {
+		esc_html_e( 'No activities found. Sync your Strava data from the Settings page.', 'graphql-strava-activities' );
+	}
+
+	/**
+	 * Extra controls above and below the table — type filter dropdown.
+	 *
+	 * @param string $which Top or bottom.
+	 * @return void
+	 */
+	protected function extra_tablenav( $which ): void {
+		if ( 'top' !== $which ) {
+			return;
+		}
+
+		$activities = wpgraphql_strava_get_cached_activities( 0 );
+		$types      = array_unique( array_column( $activities, 'type' ) );
+		sort( $types );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$current_type = isset( $_GET['activity_type'] ) ? sanitize_text_field( wp_unslash( $_GET['activity_type'] ) ) : '';
+		?>
+		<div class="alignleft actions">
+			<select name="activity_type">
+				<option value=""><?php esc_html_e( 'All Types', 'graphql-strava-activities' ); ?></option>
+				<?php foreach ( $types as $type ) : ?>
+					<option value="<?php echo esc_attr( $type ); ?>" <?php selected( $current_type, $type ); ?>>
+						<?php echo esc_html( $type ); ?>
+					</option>
+				<?php endforeach; ?>
+			</select>
+			<?php submit_button( __( 'Filter', 'graphql-strava-activities' ), '', 'filter_action', false ); ?>
+		</div>
+		<?php
+	}
+}

--- a/wp-graphql-strava.php
+++ b/wp-graphql-strava.php
@@ -108,6 +108,7 @@ function wpgraphql_strava_init(): void {
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/api.php';
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/cache.php';
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/admin.php';
+	require_once WPGRAPHQL_STRAVA_DIR . 'includes/class-wpgraphql-strava-activities-list-table.php';
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/graphql.php';
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/shortcodes.php';
 }


### PR DESCRIPTION
## Summary
- **Strava → Activities** submenu with WP_List_Table
- Columns: Title, Type, Distance, Duration, Date, Route, Photo, Strava link
- Pagination (20/page), sortable columns, type filter dropdown
- Private activity badge, route/photo check indicators
- Shared "Built by" footer on all 4 plugin admin pages

Closes #53

## Test plan
- [x] All checks pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)