### PR TITLE
Fix field count in CLAUDE.md, add missing .distignore entries

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -19,4 +19,6 @@
 /SUPPORT.md
 /grumphp.yml
 /phpunit.xml.dist
+/phpstan.neon.dist
+/stubs/
 /tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ that depend on them. The bootstrap file handles this.
 
 ## GraphQL Fields
 
-The `StravaActivity` type exposes 21 fields. All come from the Strava list endpoint
+The `StravaActivity` type exposes 20 fields. All come from the Strava list endpoint
 (no extra API calls needed):
 
 | Field | Type | Source |


### PR DESCRIPTION
## Summary
Documentation audit found 2 minor issues:
- CLAUDE.md claimed 21 fields but there are 20 — fixed
- .distignore was missing phpstan.neon.dist and stubs/ — added

## Test plan
- [x] All checks pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)