### PR TITLE
feat: add weekly, biweekly, and monthly sync options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Weekly, every 2 weeks, and monthly sync frequency options
 - "Powered by Strava" attribution in admin footer and brand attribution docs on Getting Started page
 - `poweredByStrava` GraphQL field for frontend attribution compliance
 - Strava brand-compliant orange (#FC5200) styling on admin "View on Strava" links

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -213,7 +213,7 @@ function wpgraphql_strava_register_settings(): void {
 		'wpgraphql_strava_cron_schedule',
 		[
 			'type'              => 'string',
-			'sanitize_callback' => static fn( $val ) => in_array( $val, [ 'every_15_minutes', 'every_30_minutes', 'hourly', 'every_2_hours', 'every_4_hours', 'every_6_hours', 'twicedaily', 'daily' ], true ) ? $val : 'twicedaily',
+			'sanitize_callback' => static fn( $val ) => in_array( $val, [ 'every_15_minutes', 'every_30_minutes', 'hourly', 'every_2_hours', 'every_4_hours', 'every_6_hours', 'twicedaily', 'daily', 'weekly', 'every_2_weeks', 'monthly' ], true ) ? $val : 'twicedaily',
 			'default'           => 'twicedaily',
 		]
 	);
@@ -424,6 +424,9 @@ function wpgraphql_strava_render_cron_field(): void {
 		'every_6_hours'    => __( 'Every 6 Hours', 'graphql-strava-activities' ),
 		'twicedaily'       => __( 'Every 12 Hours', 'graphql-strava-activities' ),
 		'daily'            => __( 'Once Daily', 'graphql-strava-activities' ),
+		'weekly'           => __( 'Once Weekly', 'graphql-strava-activities' ),
+		'every_2_weeks'    => __( 'Every 2 Weeks', 'graphql-strava-activities' ),
+		'monthly'          => __( 'Monthly', 'graphql-strava-activities' ),
 	];
 
 	// Estimate daily API calls: ~6 per sync × syncs per day.
@@ -436,9 +439,12 @@ function wpgraphql_strava_render_cron_field(): void {
 		'every_6_hours'    => 4,
 		'twicedaily'       => 2,
 		'daily'            => 1,
+		'weekly'           => 1.0 / 7,
+		'every_2_weeks'    => 1.0 / 14,
+		'monthly'          => 1.0 / 30,
 	];
 	$syncs_per_day = $intervals[ $value ] ?? 2;
-	$daily_calls   = $syncs_per_day * 6;
+	$daily_calls   = (int) max( 1, ceil( $syncs_per_day * 6 ) );
 	?>
 	<select name="wpgraphql_strava_cron_schedule">
 		<?php foreach ( $options as $key => $label ) : ?>

--- a/wp-graphql-strava.php
+++ b/wp-graphql-strava.php
@@ -146,6 +146,18 @@ function wpgraphql_strava_cron_schedules( array $schedules ): array {
 			'interval' => 6 * HOUR_IN_SECONDS,
 			'display'  => __( 'Every 6 Hours', 'graphql-strava-activities' ),
 		],
+		'weekly'           => [
+			'interval' => 7 * DAY_IN_SECONDS,
+			'display'  => __( 'Once Weekly', 'graphql-strava-activities' ),
+		],
+		'every_2_weeks'    => [
+			'interval' => 14 * DAY_IN_SECONDS,
+			'display'  => __( 'Every 2 Weeks', 'graphql-strava-activities' ),
+		],
+		'monthly'          => [
+			'interval' => 30 * DAY_IN_SECONDS,
+			'display'  => __( 'Monthly', 'graphql-strava-activities' ),
+		],
 	];
 
 	return array_merge( $schedules, $custom );


### PR DESCRIPTION
## Summary
- Register three new WordPress cron schedules: weekly (7 days), every 2 weeks (14 days), monthly (30 days)
- Add all three to the sync frequency dropdown in Settings
- Update sanitization whitelist and estimated API usage display

Closes #52

## Test plan
- [ ] Verify new options appear in Settings → Sync Frequency dropdown
- [ ] Select "Monthly" and save — verify cron reschedules correctly
- [ ] Verify estimated API usage shows `~1 calls/day` for weekly/biweekly/monthly
- [ ] Run `composer test` — all 35 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)