### PR TITLE
docs: update all documentation for sync frequencies and fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated readme.txt sync frequency description and GraphQL example to include all 21 fields
+- Added `composer analyse` command to CLAUDE.md
+- Added `poweredByStrava` field to README.md GraphQL example
+
 ### Added
 - Weekly, every 2 weeks, and monthly sync frequency options
 - "Powered by Strava" attribution in admin footer and brand attribution docs on Getting Started page

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,7 @@ All filters use the `wpgraphql_strava_` prefix:
 composer install      # Install dev dependencies + GrumPHP pre-commit hooks
 composer lint         # Check coding standards
 composer lint:fix     # Auto-fix violations
+composer analyse      # Run PHPStan static analysis (level 5)
 composer test         # Run all tests
 composer test:unit    # Run unit tests only
 composer test:integration  # Run integration tests only

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Activate in WordPress, then visit **Strava** in the admin menu.
     city
     country
     isPrivate
+    poweredByStrava
   }
 }
 ```

--- a/readme.txt
+++ b/readme.txt
@@ -28,7 +28,7 @@ GraphQL Strava Activities brings your Strava activities into your headless WordP
 * **Caching** — Transient-based caching with configurable TTL to stay within Strava rate limits.
 * **Admin Settings** — Full settings page for credentials, SVG customization, display units, and sync controls.
 * **Credential Encryption** — Optional AES-256-CBC at-rest encryption for your API tokens.
-* **Configurable Sync** — Choose hourly, twice daily, or daily sync frequency.
+* **Configurable Sync** — Choose from 11 sync frequencies: every 15 minutes to monthly.
 * **Extensible** — Filters and hooks for customizing cache TTL, SVG appearance, activity types, and more.
 
 **Example GraphQL Query:**
@@ -46,11 +46,16 @@ GraphQL Strava Activities brings your Strava activities into your headless WordP
         photoUrl
         elevationGain
         averageSpeed
+        maxSpeed
+        averageHeartrate
+        maxHeartrate
         calories
         kudosCount
+        commentCount
         city
         country
         isPrivate
+        poweredByStrava
       }
     }
 
@@ -92,7 +97,7 @@ Yes. WPGraphQL 2.0 or newer is a hard dependency — the plugin will not activat
 
 = How often are activities synced? =
 
-By default, activities are cached and refreshed every 12 hours via WordPress cron. You can also trigger a manual resync from the admin settings page.
+By default, activities are cached and refreshed every 12 hours via WordPress cron. You can choose from 11 sync frequencies (every 15 minutes, 30 minutes, hourly, every 2/4/6/12 hours, daily, weekly, every 2 weeks, or monthly) in the settings. You can also trigger a manual resync from the admin settings page.
 
 = Can I change the SVG route map appearance? =
 


### PR DESCRIPTION
## Summary
- Add `composer analyse` command to CLAUDE.md (was missing)
- Update readme.txt sync frequency description to reflect all 11 options (was "hourly, twice daily, or daily")
- Add 5 missing fields to readme.txt GraphQL example (`maxSpeed`, `averageHeartrate`, `maxHeartrate`, `commentCount`, `poweredByStrava`)
- Add `poweredByStrava` field to README.md GraphQL example

## Test plan
- [ ] Verify all documentation matches actual code
- [ ] `composer test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)