### PR TITLE
fix: add missing phpstan to pre-commit hooks in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ No build step — pure PHP plugin.
 
 GrumPHP runs automatically on every commit (installed via `composer install`):
 1. **phpcs** — WordPress coding standards check on changed PHP files
-2. **phpunit** — full test suite
+2. **phpstan** — PHPStan level 5 static analysis
+3. **phpunit** — full test suite
 
-If either fails, the commit is blocked. Fix the issues and try again.
+If any task fails, the commit is blocked. Fix the issues and try again.


### PR DESCRIPTION
## Summary
- Add missing phpstan entry to the pre-commit hooks section in CLAUDE.md
- GrumPHP runs 3 tasks (phpcs, phpstan, phpunit), not 2

## Test plan
- [x] Verified grumphp.yml has all 3 tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)