### PR TITLE
fix: remove Powered by Strava from docs footer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -38,8 +38,7 @@
             ' · <a href="https://www.buymeacoffee.com/shawnazar" target="_blank" rel="noopener noreferrer">Buy Me a Coffee</a>',
             ' · <a href="https://github.com/shawnazar/wp-graphql-strava" target="_blank" rel="noopener noreferrer">GitHub</a>',
             ' · <a href="https://github.com/shawnazar/wp-graphql-strava/issues" target="_blank" rel="noopener noreferrer">Report an Issue</a>',
-            ' · <a href="https://github.com/shawnazar/wp-graphql-strava/discussions" target="_blank" rel="noopener noreferrer">Discussions</a>',
-            ' · Powered by <a href="https://www.strava.com" target="_blank" rel="noopener noreferrer" style="color: #FC5200; font-weight: bold;">Strava</a></p>',
+            ' · <a href="https://github.com/shawnazar/wp-graphql-strava/discussions" target="_blank" rel="noopener noreferrer">Discussions</a></p>',
             '</footer>'
           ].join('');
 


### PR DESCRIPTION
## Summary
- Remove "Powered by Strava" from docs site footer to avoid implying sponsorship

🤖 Generated with [Claude Code](https://claude.com/claude-code)