### PR TITLE
Use 'Compatible with Strava' language per brand guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-orange.svg)](https://www.buymeacoffee.com/shawnazar)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue.svg)](https://shawnazar.github.io/wp-graphql-strava/)
 
-A WordPress plugin that extends [WPGraphQL](https://www.wpgraphql.com/) with Strava activity data, server-side SVG route maps, and activity photos — no JavaScript map libraries required.
+Compatible with Strava — a WordPress plugin that extends [WPGraphQL](https://www.wpgraphql.com/) with activity data, server-side SVG route maps, and photos. No JavaScript map libraries required.
 
 ## Features
 

--- a/readme.txt
+++ b/readme.txt
@@ -9,7 +9,7 @@ Stable tag: 1.0.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
-Extends WPGraphQL with Strava activity data, server-side SVG route maps, and activity photos.
+Compatible with Strava — extends WPGraphQL with activity data, server-side SVG route maps, and photos.
 
 == Description ==
 

--- a/wp-graphql-strava.php
+++ b/wp-graphql-strava.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       GraphQL Strava Activities
  * Plugin URI:        https://github.com/shawnazar/wp-graphql-strava
- * Description:       Extends WPGraphQL with Strava activity data, server-side SVG route maps, and activity photos.
+ * Description:       Compatible with Strava — extends WPGraphQL with activity data, server-side SVG route maps, and photos.
  * Version:           1.0.0
  * Requires at least: 6.0
  * Requires PHP:      8.2


### PR DESCRIPTION
## Summary
Updated plugin description to lead with "Compatible with Strava" — an approved phrase per Strava's brand guidelines:
- Plugin header description
- readme.txt short description
- README.md tagline

Closes #28

## Test plan
- [x] All checks pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)