### PR TITLE
Rename main file and references to match WordPress.org slug

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 # Security-sensitive files require explicit review
 includes/encryption.php @shawnazar
 includes/api.php @shawnazar
-wp-graphql-strava.php @shawnazar
+graphql-strava-activities.php @shawnazar
 .github/workflows/ @shawnazar

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions & Help
-    url: https://github.com/shawnazar/wp-graphql-strava/discussions
+    url: https://github.com/shawnazar/graphql-strava-activities/discussions
     about: Ask questions and get help from the community. Please don't open issues for general questions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Strava activity data, server-side SVG route maps, and activity photos.
 ## Architecture
 
 ```
-wp-graphql-strava.php          # Bootstrap, dependency check, cron scheduling
+graphql-strava-activities.php          # Bootstrap, dependency check, cron scheduling
 includes/
 ├── encryption.php             # Optional AES-256-CBC credential encryption
 ├── polyline.php               # Google encoded polyline → [lat, lng] decoder

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing! This guide will help you get starte
 
 ## Reporting Bugs
 
-1. Search [existing issues](https://github.com/shawnazar/wp-graphql-strava/issues) to avoid duplicates.
+1. Search [existing issues](https://github.com/shawnazar/graphql-strava-activities/issues) to avoid duplicates.
 2. Open a new issue with:
    - WordPress, PHP, and WPGraphQL versions
    - Steps to reproduce
@@ -13,7 +13,7 @@ Thank you for your interest in contributing! This guide will help you get starte
 
 ## Suggesting Features
 
-Open a [GitHub issue](https://github.com/shawnazar/wp-graphql-strava/issues/new) describing:
+Open a [GitHub issue](https://github.com/shawnazar/graphql-strava-activities/issues/new) describing:
 - What you'd like to see
 - Why it would be useful
 - Any implementation ideas
@@ -24,7 +24,7 @@ Open a [GitHub issue](https://github.com/shawnazar/wp-graphql-strava/issues/new)
 2. Mount the plugin in a local WordPress environment:
    ```bash
    cd wp-content/plugins/
-   git clone https://github.com/YOUR-USERNAME/wp-graphql-strava.git graphql-strava-activities
+   git clone https://github.com/YOUR-USERNAME/graphql-strava-activities.git graphql-strava-activities
    ```
 3. Install dev dependencies:
    ```bash

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![WordPress 6.0+](https://img.shields.io/badge/WordPress-6.0%2B-21759B.svg)](https://wordpress.org/)
 [![WPGraphQL 2.0+](https://img.shields.io/badge/WPGraphQL-2.0%2B-4B32C3.svg)](https://www.wpgraphql.com/)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-orange.svg)](https://www.buymeacoffee.com/shawnazar)
-[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue.svg)](https://shawnazar.github.io/wp-graphql-strava/)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue.svg)](https://shawnazar.github.io/graphql-strava-activities/)
 
 Compatible with Strava — a WordPress plugin that extends [WPGraphQL](https://www.wpgraphql.com/) with activity data, server-side SVG route maps, and photos. No JavaScript map libraries required.
 
@@ -36,7 +36,7 @@ Compatible with Strava — a WordPress plugin that extends [WPGraphQL](https://w
 
 ```bash
 cd wp-content/plugins/
-git clone https://github.com/shawnazar/wp-graphql-strava.git graphql-strava-activities
+git clone https://github.com/shawnazar/graphql-strava-activities.git graphql-strava-activities
 ```
 
 Activate in WordPress, then visit **Strava** in the admin menu.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,9 +2,9 @@
 
 ## Getting Help
 
-- **Questions & How-To** — Use [GitHub Discussions (Q&A)](https://github.com/shawnazar/wp-graphql-strava/discussions/categories/q-a). Please don't open issues for general questions.
-- **Bug Reports** — [Open an issue](https://github.com/shawnazar/wp-graphql-strava/issues/new?template=bug_report.yml) with steps to reproduce.
-- **Feature Requests** — [Open an issue](https://github.com/shawnazar/wp-graphql-strava/issues/new?template=feature_request.yml) describing the problem and proposed solution.
+- **Questions & How-To** — Use [GitHub Discussions (Q&A)](https://github.com/shawnazar/graphql-strava-activities/discussions/categories/q-a). Please don't open issues for general questions.
+- **Bug Reports** — [Open an issue](https://github.com/shawnazar/graphql-strava-activities/issues/new?template=bug_report.yml) with steps to reproduce.
+- **Feature Requests** — [Open an issue](https://github.com/shawnazar/graphql-strava-activities/issues/new?template=feature_request.yml) describing the problem and proposed solution.
 - **Security Issues** — See [SECURITY.md](SECURITY.md). Do not use public issues for security reports.
 
 ## In-Plugin Help
@@ -17,6 +17,6 @@ After activating the plugin, visit **Strava → Getting Started** in your WordPr
 
 ## Before Asking
 
-1. Check the [Getting Started page](https://github.com/shawnazar/wp-graphql-strava#quick-start) in the README
-2. Search [existing issues](https://github.com/shawnazar/wp-graphql-strava/issues) and [discussions](https://github.com/shawnazar/wp-graphql-strava/discussions)
+1. Check the [Getting Started page](https://github.com/shawnazar/graphql-strava-activities#quick-start) in the README
+2. Search [existing issues](https://github.com/shawnazar/graphql-strava-activities/issues) and [discussions](https://github.com/shawnazar/graphql-strava-activities/discussions)
 3. Make sure you're on the latest version of the plugin

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "shawnazar/wp-graphql-strava",
+  "name": "shawnazar/graphql-strava-activities",
   "description": "GraphQL Strava Activities — extends WPGraphQL with Strava activity data and server-side SVG route maps.",
   "type": "wordpress-plugin",
   "license": "MIT",

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,6 @@ Use the sidebar to navigate the full documentation, covering everything from ini
 
 ## Links
 
-- [GitHub Repository](https://github.com/shawnazar/wp-graphql-strava)
-- [Report an Issue](https://github.com/shawnazar/wp-graphql-strava/issues)
-- [Discussions](https://github.com/shawnazar/wp-graphql-strava/discussions)
+- [GitHub Repository](https://github.com/shawnazar/graphql-strava-activities)
+- [Report an Issue](https://github.com/shawnazar/graphql-strava-activities/issues)
+- [Discussions](https://github.com/shawnazar/graphql-strava-activities/discussions)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,7 @@
 ## File Structure
 
 ```
-wp-graphql-strava.php          # Bootstrap, dependency check, cron scheduling
+graphql-strava-activities.php          # Bootstrap, dependency check, cron scheduling
 includes/
 ├── encryption.php             # Optional AES-256-CBC credential encryption
 ├── polyline.php               # Google encoded polyline → [lat, lng] decoder
@@ -18,7 +18,7 @@ includes/
 
 ## Load Order
 
-Load order matters — `encryption.php` and `polyline.php` must load before modules that depend on them. The bootstrap file (`wp-graphql-strava.php`) handles this:
+Load order matters — `encryption.php` and `polyline.php` must load before modules that depend on them. The bootstrap file (`graphql-strava-activities.php`) handles this:
 
 1. `encryption.php` — needed by api.php and admin.php for credential access
 2. `polyline.php` — needed by svg.php for polyline decoding

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,7 +5,7 @@
 1. Fork and clone the repository:
    ```bash
    cd wp-content/plugins/
-   git clone https://github.com/YOUR-USERNAME/wp-graphql-strava.git graphql-strava-activities
+   git clone https://github.com/YOUR-USERNAME/graphql-strava-activities.git graphql-strava-activities
    ```
 2. Install dev dependencies:
    ```bash
@@ -69,7 +69,7 @@ If any task fails, the commit is blocked.
 
 ## Reporting Bugs
 
-Open a [GitHub issue](https://github.com/shawnazar/wp-graphql-strava/issues) with:
+Open a [GitHub issue](https://github.com/shawnazar/graphql-strava-activities/issues) with:
 - WordPress, PHP, and WPGraphQL versions
 - Steps to reproduce
 - Expected vs actual behaviour

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ This guide walks you through installing the plugin, connecting your Strava accou
 
 ### From WordPress Admin
 
-1. Download the plugin zip from [GitHub Releases](https://github.com/shawnazar/wp-graphql-strava/releases)
+1. Download the plugin zip from [GitHub Releases](https://github.com/shawnazar/graphql-strava-activities/releases)
 2. Go to **Plugins → Add New → Upload Plugin**
 3. Upload the zip and click **Install Now**
 4. Activate the plugin
@@ -21,7 +21,7 @@ This guide walks you through installing the plugin, connecting your Strava accou
 
 ```bash
 cd wp-content/plugins/
-git clone https://github.com/shawnazar/wp-graphql-strava.git graphql-strava-activities
+git clone https://github.com/shawnazar/graphql-strava-activities.git graphql-strava-activities
 ```
 
 Activate in **Plugins** menu.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -4,7 +4,7 @@
 
 1. Update `CHANGELOG.md` — move items from `[Unreleased]` to a new version section
 2. Update the version number in:
-   - `wp-graphql-strava.php` (plugin header `Version:` and `WPGRAPHQL_STRAVA_VERSION` constant)
+   - `graphql-strava-activities.php` (plugin header `Version:` and `WPGRAPHQL_STRAVA_VERSION` constant)
    - `readme.txt` (`Stable tag:`)
 3. Commit: `git commit -m "release: v1.2.0"`
 4. Tag: `git tag v1.2.0`

--- a/docs/static-analysis.md
+++ b/docs/static-analysis.md
@@ -13,7 +13,7 @@ composer analyse
 PHPStan is configured in `phpstan.neon.dist`:
 
 - **Level**: 5
-- **Paths**: `wp-graphql-strava.php`, `includes/`
+- **Paths**: `graphql-strava-activities.php`, `includes/`
 - **WordPress extension**: Provides stubs for WordPress functions, hooks, and globals
 - **Custom stubs**: Located in `stubs/` for any additional function declarations
 

--- a/graphql-strava-activities.php
+++ b/graphql-strava-activities.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:       GraphQL Strava Activities
- * Plugin URI:        https://github.com/shawnazar/wp-graphql-strava
+ * Plugin URI:        https://github.com/shawnazar/graphql-strava-activities
  * Description:       Compatible with Strava — extends WPGraphQL with activity data, server-side SVG route maps, and photos.
  * Version:           1.0.0
  * Requires at least: 6.0

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -545,11 +545,11 @@ function wpgraphql_strava_render_admin_footer(): void {
 		<span>&middot;</span>
 		<a href="https://www.buymeacoffee.com/shawnazar" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Buy Me a Coffee', 'graphql-strava-activities' ); ?></a>
 		<span>&middot;</span>
-		<a href="https://github.com/shawnazar/wp-graphql-strava" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'GitHub', 'graphql-strava-activities' ); ?></a>
+		<a href="https://github.com/shawnazar/graphql-strava-activities" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'GitHub', 'graphql-strava-activities' ); ?></a>
 		<span>&middot;</span>
-		<a href="https://github.com/shawnazar/wp-graphql-strava/issues" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Report an Issue', 'graphql-strava-activities' ); ?></a>
+		<a href="https://github.com/shawnazar/graphql-strava-activities/issues" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Report an Issue', 'graphql-strava-activities' ); ?></a>
 		<span>&middot;</span>
-		<a href="https://github.com/shawnazar/wp-graphql-strava/discussions" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Discussions', 'graphql-strava-activities' ); ?></a>
+		<a href="https://github.com/shawnazar/graphql-strava-activities/discussions" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Discussions', 'graphql-strava-activities' ); ?></a>
 		<span>&middot;</span>
 		<span>
 			<?php

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
     <description>WordPress Coding Standards for GraphQL Strava Activities.</description>
 
     <!-- Scan these files -->
-    <file>wp-graphql-strava.php</file>
+    <file>graphql-strava-activities.php</file>
     <file>includes/</file>
 
     <!-- Exclude stubs and tests from scanning -->

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,7 +4,7 @@ includes:
 parameters:
     level: 5
     paths:
-        - wp-graphql-strava.php
+        - graphql-strava-activities.php
         - includes/
     excludePaths:
         - vendor/


### PR DESCRIPTION
## Summary
- Renamed `wp-graphql-strava.php` → `graphql-strava-activities.php`
- Updated all GitHub URLs to `shawnazar/graphql-strava-activities`
- Updated composer.json, phpcs.xml.dist, phpstan.neon.dist, CODEOWNERS, issue templates, all docs
- Fixes all plugin checker text domain mismatch warnings and "wp" restricted term warning

Closes #66

## Test plan
- [x] All checks pass locally (lint, analyse, 35 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)