### PR TITLE
fix: resolve WordPress plugin check errors and warnings

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -5,6 +5,7 @@
 /.github/
 /.gitignore
 /.distignore
+/.phpunit.result.cache
 /composer.json
 /composer.lock
 /node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Replaced `error_log()` calls in API client with `wp_trigger_error()` for production use
+- Replaced `strip_tags()` in test mock with `wp_strip_all_tags()` for WPCS compliance
+- Renamed `GRAPHQL_STRAVA_ENCRYPTION_KEY` constant to `WPGRAPHQL_STRAVA_ENCRYPTION_KEY` to match plugin prefix convention
+- Added `phpcs:ignore` comments on WPGraphQL stub functions (must match upstream names)
+- Added `.phpunit.result.cache` to `.distignore`
+- Updated "Tested up to" to WordPress 6.9
+
 ### Changed
 - GitHub Pages documentation site with Docsify (user guide + developer guide)
 - Updated readme.txt sync frequency description and GraphQL example to include all 21 fields

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ For non-headless WordPress sites — use in posts and pages:
 Add to `wp-config.php`:
 
 ```php
-define( 'GRAPHQL_STRAVA_ENCRYPTION_KEY', 'your-64-char-hex-key' );
+define( 'WPGRAPHQL_STRAVA_ENCRYPTION_KEY', 'your-64-char-hex-key' );
 ```
 
 Generate a key: `wp eval "echo bin2hex(random_bytes(32));"`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ This policy covers the GraphQL Strava Activities WordPress plugin code in this r
 ## Credential Storage
 
 - API tokens are stored in the WordPress `wp_options` table
-- Optional AES-256-CBC encryption is available via the `GRAPHQL_STRAVA_ENCRYPTION_KEY` constant in `wp-config.php`
+- Optional AES-256-CBC encryption is available via the `WPGRAPHQL_STRAVA_ENCRYPTION_KEY` constant in `wp-config.php`
 - All credentials are sanitized before storage and escaped on output
 
 ## Best Practices for Users

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -11,7 +11,7 @@ By default, WordPress stores option values as plain text in the `wp_options` dat
 Add this to your `wp-config.php`:
 
 ```php
-define( 'GRAPHQL_STRAVA_ENCRYPTION_KEY', 'your-64-character-hex-key' );
+define( 'WPGRAPHQL_STRAVA_ENCRYPTION_KEY', 'your-64-character-hex-key' );
 ```
 
 ### Generate a Key
@@ -32,7 +32,7 @@ This produces a 64-character hex string (256-bit key).
 
 ## How It Works
 
-When `GRAPHQL_STRAVA_ENCRYPTION_KEY` is defined:
+When `WPGRAPHQL_STRAVA_ENCRYPTION_KEY` is defined:
 
 1. **Saving** — Values are encrypted with AES-256-CBC before being stored in `wp_options`. Encrypted values are prefixed with `enc:` for identification.
 2. **Reading** — Values prefixed with `enc:` are decrypted on retrieval.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -40,7 +40,7 @@ The plugin sends your OAuth tokens to authenticate API requests. No personal dat
 
 ## How do I enable credential encryption?
 
-Add a `GRAPHQL_STRAVA_ENCRYPTION_KEY` constant to `wp-config.php`. See [Encryption](encryption.md) for full setup instructions.
+Add a `WPGRAPHQL_STRAVA_ENCRYPTION_KEY` constant to `wp-config.php`. See [Encryption](encryption.md) for full setup instructions.
 
 ## Is there a rate limit?
 

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -765,7 +765,7 @@ function wpgraphql_strava_render_guide_page(): void {
 			<div class="card" style="max-width: 800px; padding: 16px 24px;">
 				<h2 style="margin-top: 8px;"><?php esc_html_e( 'Credential Encryption (Optional)', 'graphql-strava-activities' ); ?></h2>
 				<p><?php esc_html_e( 'For additional security, you can encrypt your stored credentials at rest. Add this line to your wp-config.php:', 'graphql-strava-activities' ); ?></p>
-				<code style="display: block; padding: 8px; margin: 8px 0; background: #f0f0f1; font-size: 13px;">define( 'GRAPHQL_STRAVA_ENCRYPTION_KEY', 'your-64-character-hex-key' );</code>
+				<code style="display: block; padding: 8px; margin: 8px 0; background: #f0f0f1; font-size: 13px;">define( 'WPGRAPHQL_STRAVA_ENCRYPTION_KEY', 'your-64-character-hex-key' );</code>
 				<p><?php esc_html_e( 'Generate a key with:', 'graphql-strava-activities' ); ?>
 					<code>wp eval "echo bin2hex(random_bytes(32));"</code>
 				</p>

--- a/includes/api.php
+++ b/includes/api.php
@@ -58,14 +58,14 @@ function wpgraphql_strava_fetch_activities( int $count = 200 ): array {
 	);
 
 	if ( is_wp_error( $response ) ) {
-		error_log( 'WPGraphQL Strava: API error — ' . $response->get_error_message() );
+		wp_trigger_error( __FUNCTION__, 'WPGraphQL Strava: API error — ' . $response->get_error_message() );
 		return [];
 	}
 
 	$status_code = wp_remote_retrieve_response_code( $response );
 
 	if ( 200 !== $status_code ) {
-		error_log( 'WPGraphQL Strava: API returned status ' . $status_code );
+		wp_trigger_error( __FUNCTION__, 'WPGraphQL Strava: API returned status ' . $status_code );
 
 		// Try refreshing the token once on 401.
 		if ( 401 === $status_code ) {
@@ -181,7 +181,7 @@ function wpgraphql_strava_refresh_access_token(): string {
 	);
 
 	if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-		error_log( 'WPGraphQL Strava: token refresh failed.' );
+		wp_trigger_error( __FUNCTION__, 'WPGraphQL Strava: token refresh failed.' );
 		return '';
 	}
 

--- a/includes/encryption.php
+++ b/includes/encryption.php
@@ -6,9 +6,9 @@
  * stored in wp_options and decrypts them on retrieval. Uses AES-256-CBC
  * via OpenSSL.
  *
- * To enable, define GRAPHQL_STRAVA_ENCRYPTION_KEY in wp-config.php:
+ * To enable, define WPGRAPHQL_STRAVA_ENCRYPTION_KEY in wp-config.php:
  *
- *     define( 'GRAPHQL_STRAVA_ENCRYPTION_KEY', 'your-random-64-char-hex-string' );
+ *     define( 'WPGRAPHQL_STRAVA_ENCRYPTION_KEY', 'your-random-64-char-hex-string' );
  *
  * Generate a key with: wp eval "echo bin2hex(random_bytes(32));"
  *
@@ -51,8 +51,8 @@ define(
  * @return bool True when a valid encryption key is defined and OpenSSL is loaded.
  */
 function wpgraphql_strava_encryption_enabled(): bool {
-	return defined( 'GRAPHQL_STRAVA_ENCRYPTION_KEY' )
-		&& ! empty( GRAPHQL_STRAVA_ENCRYPTION_KEY )
+	return defined( 'WPGRAPHQL_STRAVA_ENCRYPTION_KEY' )
+		&& ! empty( WPGRAPHQL_STRAVA_ENCRYPTION_KEY )
 		&& function_exists( 'openssl_encrypt' );
 }
 
@@ -67,7 +67,7 @@ function wpgraphql_strava_encrypt( string $value ): string {
 		return $value;
 	}
 
-	$key    = hex2bin( GRAPHQL_STRAVA_ENCRYPTION_KEY );
+	$key    = hex2bin( WPGRAPHQL_STRAVA_ENCRYPTION_KEY );
 	$iv_len = openssl_cipher_iv_length( WPGRAPHQL_STRAVA_CIPHER );
 
 	if ( false === $key || false === $iv_len ) {
@@ -103,7 +103,7 @@ function wpgraphql_strava_decrypt( string $value ): string {
 		return '';
 	}
 
-	$key    = hex2bin( GRAPHQL_STRAVA_ENCRYPTION_KEY );
+	$key    = hex2bin( WPGRAPHQL_STRAVA_ENCRYPTION_KEY );
 	$iv_len = openssl_cipher_iv_length( WPGRAPHQL_STRAVA_CIPHER );
 
 	if ( false === $key || false === $iv_len ) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,9 +15,9 @@ parameters:
         - stubs/wpgraphql.php
     treatPhpDocTypesAsCertain: false
     dynamicConstantNames:
-        - GRAPHQL_STRAVA_ENCRYPTION_KEY
+        - WPGRAPHQL_STRAVA_ENCRYPTION_KEY
     ignoreErrors:
         - '#PHPDoc tag @var does not specify variable name#'
-        - '#Constant GRAPHQL_STRAVA_ENCRYPTION_KEY not found#'
+        - '#Constant WPGRAPHQL_STRAVA_ENCRYPTION_KEY not found#'
     scanFiles:
         - stubs/wpgraphql.php

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: shawnazar
 Tags: graphql, strava, wpgraphql, fitness, activities
 Requires at least: 6.0
-Tested up to: 6.7
+Tested up to: 6.9
 Requires PHP: 8.2
 Requires Plugins: wp-graphql
 Stable tag: 1.0.0

--- a/stubs/wpgraphql.php
+++ b/stubs/wpgraphql.php
@@ -5,12 +5,16 @@
  * @package WPGraphQL\Strava
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * @param string               $type_name Type name.
  * @param array<string, mixed> $config    Type configuration.
  * @return void
  */
-function register_graphql_object_type( string $type_name, array $config ): void {}
+function register_graphql_object_type( string $type_name, array $config ): void {} // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- WPGraphQL stub.
 
 /**
  * @param string               $type_name  Type to extend.
@@ -18,4 +22,4 @@ function register_graphql_object_type( string $type_name, array $config ): void 
  * @param array<string, mixed> $config     Field configuration.
  * @return void
  */
-function register_graphql_field( string $type_name, string $field_name, array $config ): void {}
+function register_graphql_field( string $type_name, string $field_name, array $config ): void {} // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- WPGraphQL stub.

--- a/tests/Integration/CacheTest.php
+++ b/tests/Integration/CacheTest.php
@@ -84,9 +84,15 @@ class CacheTest extends TestCase {
             }
         );
 
+        Functions\when( 'wp_strip_all_tags' )->alias(
+            function ( string $str ) {
+                return strip_tags( $str ); // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags -- test mock.
+            }
+        );
+
         Functions\when( 'sanitize_text_field' )->alias(
             function ( string $str ) {
-                return trim( strip_tags( $str ) );
+                return trim( wp_strip_all_tags( $str ) );
             }
         );
 

--- a/tests/Unit/EncryptionTest.php
+++ b/tests/Unit/EncryptionTest.php
@@ -23,8 +23,8 @@ class EncryptionTest extends TestCase {
         parent::setUp();
 
         // Define the encryption key if not already defined.
-        if ( ! defined( 'GRAPHQL_STRAVA_ENCRYPTION_KEY' ) ) {
-            define( 'GRAPHQL_STRAVA_ENCRYPTION_KEY', bin2hex( random_bytes( 32 ) ) );
+        if ( ! defined( 'WPGRAPHQL_STRAVA_ENCRYPTION_KEY' ) ) {
+            define( 'WPGRAPHQL_STRAVA_ENCRYPTION_KEY', bin2hex( random_bytes( 32 ) ) );
         }
     }
 


### PR DESCRIPTION
## Summary
- Replaced `error_log()` with `wp_trigger_error()` in `includes/api.php`
- Renamed `GRAPHQL_STRAVA_ENCRYPTION_KEY` → `WPGRAPHQL_STRAVA_ENCRYPTION_KEY` across all files (breaking change for existing users — must update `wp-config.php`)
- Replaced `strip_tags()` with `wp_strip_all_tags()` mock in integration tests
- Added `phpcs:ignore` on WPGraphQL stub functions (must match upstream names)
- Added `.phpunit.result.cache` to `.distignore`
- Bumped "Tested up to" to WordPress 6.9

## Test plan
- [x] `composer test` — 35 tests, 85 assertions pass
- [x] `composer lint` — clean
- [x] `composer analyse` — no errors
- [ ] Download zip and re-run WordPress Plugin Check against the built distribution

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)