### PR TITLE
feat: one-click OAuth flow for Strava authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- One-click "Connect with Strava" OAuth flow — eliminates manual curl token exchange
+- OAuth callback handler with CSRF protection via state nonce
+- Automatic first sync after successful OAuth authorization
+
 ## [1.0.3] - 2026-03-15
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ includes/
 ├── cache.php                  # Transient caching, photo enrichment, normalization
 ├── admin.php                  # Settings page + Getting Started + Preview + Activities
 ├── graphql.php                # StravaActivity type + stravaActivities query
+├── oauth.php                  # Strava OAuth callback handler (one-click connect)
 ├── shortcodes.php             # WordPress shortcodes for non-headless sites
 ├── updater.php                # Self-hosted update checker via GitHub Releases API
 └── class-wpgraphql-strava-activities-list-table.php  # WP_List_Table for Activities page

--- a/graphql-strava-activities.php
+++ b/graphql-strava-activities.php
@@ -106,6 +106,7 @@ function wpgraphql_strava_init(): void {
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/svg.php';
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/api.php';
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/cache.php';
+	require_once WPGRAPHQL_STRAVA_DIR . 'includes/oauth.php';
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/admin.php';
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/class-wpgraphql-strava-activities-list-table.php';
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/graphql.php';

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -17,6 +17,43 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'admin_menu', 'wpgraphql_strava_add_admin_menu' );
 add_action( 'admin_init', 'wpgraphql_strava_register_settings' );
 add_action( 'admin_init', 'wpgraphql_strava_handle_resync' );
+add_action( 'admin_init', 'wpgraphql_strava_intercept_oauth_redirect' );
+
+/**
+ * Intercept the Strava OAuth redirect on the settings page.
+ *
+ * Strava sends the user back with ?code=...&state=... in the URL.
+ * We rewrite these to our handler's expected parameter names and redirect.
+ *
+ * @return void
+ */
+function wpgraphql_strava_intercept_oauth_redirect(): void {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- state parameter is verified by the handler.
+	if ( ! isset( $_GET['page'], $_GET['code'], $_GET['state'] ) ) {
+		return;
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( 'wpgraphql-strava-settings' !== $_GET['page'] ) {
+		return;
+	}
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	$redirect = add_query_arg(
+		[
+			'page'              => 'wpgraphql-strava-settings',
+			'strava_oauth_code' => sanitize_text_field( wp_unslash( $_GET['code'] ) ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			'state'             => sanitize_text_field( wp_unslash( $_GET['state'] ) ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		],
+		admin_url( 'admin.php' )
+	);
+
+	wp_safe_redirect( $redirect );
+	exit;
+}
 
 /**
  * Add a top-level "Strava" menu page.
@@ -609,6 +646,25 @@ function wpgraphql_strava_render_admin_page(): void {
 			?>
 		</form>
 
+		<?php
+		$oauth_url = function_exists( 'wpgraphql_strava_get_oauth_url' ) ? wpgraphql_strava_get_oauth_url() : '';
+		if ( ! empty( $oauth_url ) && ! $has_token ) :
+			?>
+			<div class="card" style="max-width: 600px; padding: 16px 24px; margin: 16px 0;">
+				<h3 style="margin-top: 8px;"><?php esc_html_e( 'Connect with Strava', 'graphql-strava-activities' ); ?></h3>
+				<p><?php esc_html_e( 'Save your Client ID and Client Secret above, then click the button below to authorize. Tokens will be fetched automatically.', 'graphql-strava-activities' ); ?></p>
+				<a href="<?php echo esc_url( $oauth_url ); ?>">
+					<img src="<?php echo esc_url( plugins_url( 'assets/btn-strava-connectwith-orange.svg', dirname( __DIR__ ) ) ); ?>"
+						alt="<?php esc_attr_e( 'Connect with Strava', 'graphql-strava-activities' ); ?>"
+						style="height: 48px;" />
+				</a>
+				<p style="font-size: 13px; color: #646970; margin-top: 8px;">
+					<?php esc_html_e( 'Your Strava API application\'s "Authorization Callback Domain" must be set to:', 'graphql-strava-activities' ); ?>
+					<code><?php echo esc_html( wp_parse_url( admin_url(), PHP_URL_HOST ) ); ?></code>
+				</p>
+			</div>
+		<?php endif; ?>
+
 		<hr />
 
 		<!-- Sync section -->
@@ -716,7 +772,7 @@ function wpgraphql_strava_render_guide_page(): void {
 						<?php
 						printf(
 							/* translators: %s: Link to Strava API settings */
-							esc_html__( 'Create a Strava API application at %s', 'graphql-strava-activities' ),
+							esc_html__( 'Create a Strava API application at %s (set the Authorization Callback Domain to your site\'s domain).', 'graphql-strava-activities' ),
 							'<a href="https://www.strava.com/settings/api" target="_blank" rel="noopener noreferrer">strava.com/settings/api</a>'
 						);
 						?>
@@ -725,12 +781,12 @@ function wpgraphql_strava_render_guide_page(): void {
 						<?php
 						printf(
 							/* translators: %s: Link to plugin settings page */
-							esc_html__( 'Enter your Client ID, Client Secret, Access Token, and Refresh Token on the %s page.', 'graphql-strava-activities' ),
+							esc_html__( 'Enter your Client ID and Client Secret on the %s page and click Save.', 'graphql-strava-activities' ),
 							'<a href="' . esc_url( $settings_url ) . '">' . esc_html__( 'Settings', 'graphql-strava-activities' ) . '</a>'
 						);
 						?>
 					</li>
-					<li><?php esc_html_e( 'Click "Resync Activities" to fetch your latest activities.', 'graphql-strava-activities' ); ?></li>
+					<li><?php esc_html_e( 'Click "Connect with Strava" to authorize — your tokens will be fetched automatically and activities synced.', 'graphql-strava-activities' ); ?></li>
 					<li><?php esc_html_e( 'Query your activities via GraphQL — see examples below.', 'graphql-strava-activities' ); ?></li>
 				</ol>
 			</div>
@@ -738,25 +794,59 @@ function wpgraphql_strava_render_guide_page(): void {
 			<!-- Getting Strava Tokens -->
 			<div class="card" style="max-width: 800px; padding: 16px 24px;">
 				<h2 style="margin-top: 8px;"><?php esc_html_e( 'Getting Your Strava Tokens', 'graphql-strava-activities' ); ?></h2>
-				<p><?php esc_html_e( 'After creating your Strava API application, you need to generate an Access Token and Refresh Token through the OAuth flow:', 'graphql-strava-activities' ); ?></p>
-				<ol style="font-size: 14px; line-height: 1.8;">
-					<li>
-						<?php esc_html_e( 'Visit the following URL in your browser (replace YOUR_CLIENT_ID):', 'graphql-strava-activities' ); ?>
-						<br />
+
+				<?php
+				$guide_oauth_url = function_exists( 'wpgraphql_strava_get_oauth_url' ) ? wpgraphql_strava_get_oauth_url() : '';
+				$guide_has_token = ! empty( wpgraphql_strava_get_option( 'wpgraphql_strava_access_token' ) );
+
+				if ( $guide_has_token ) :
+					?>
+					<p style="color: #00a32a; font-weight: 500;">
+						<span>&#10003;</span>
+						<?php esc_html_e( 'You are connected to Strava. Tokens are stored and will refresh automatically.', 'graphql-strava-activities' ); ?>
+					</p>
+				<?php elseif ( ! empty( $guide_oauth_url ) ) : ?>
+					<p><?php esc_html_e( 'Save your Client ID and Client Secret on the Settings page, then click below to authorize:', 'graphql-strava-activities' ); ?></p>
+					<a href="<?php echo esc_url( $guide_oauth_url ); ?>">
 						<img src="<?php echo esc_url( plugins_url( 'assets/btn-strava-connectwith-orange.svg', dirname( __DIR__ ) ) ); ?>"
 							alt="<?php esc_attr_e( 'Connect with Strava', 'graphql-strava-activities' ); ?>"
 							style="height: 48px; margin: 8px 0; display: block;" />
-						<code style="display: block; padding: 8px; margin: 8px 0; background: #f0f0f1; font-size: 13px; word-break: break-all;">https://www.strava.com/oauth/authorize?client_id=YOUR_CLIENT_ID&amp;response_type=code&amp;redirect_uri=http://localhost&amp;scope=read,activity:read_all&amp;approval_prompt=force</code>
-					</li>
-					<li><?php esc_html_e( 'Authorise the app. You will be redirected to localhost with a "code" parameter in the URL.', 'graphql-strava-activities' ); ?></li>
-					<li>
-						<?php esc_html_e( 'Exchange the code for tokens using curl or any HTTP client:', 'graphql-strava-activities' ); ?>
-						<br />
-						<code style="display: block; padding: 8px; margin: 8px 0; background: #f0f0f1; font-size: 13px; word-break: break-all;">curl -X POST https://www.strava.com/oauth/token -d client_id=YOUR_CLIENT_ID -d client_secret=YOUR_CLIENT_SECRET -d code=YOUR_CODE -d grant_type=authorization_code</code>
-					</li>
-					<li><?php esc_html_e( 'The response contains your access_token, refresh_token, and expires_at. Enter them in the plugin settings.', 'graphql-strava-activities' ); ?></li>
-				</ol>
-				<p style="font-size: 13px; color: #646970;">
+					</a>
+					<p style="font-size: 13px; color: #646970;">
+						<?php esc_html_e( 'Your Strava API application\'s "Authorization Callback Domain" must be set to:', 'graphql-strava-activities' ); ?>
+						<code><?php echo esc_html( wp_parse_url( admin_url(), PHP_URL_HOST ) ); ?></code>
+					</p>
+				<?php else : ?>
+					<p>
+						<?php
+						printf(
+							/* translators: %s: Link to settings page */
+							esc_html__( 'First, enter your Client ID on the %s page.', 'graphql-strava-activities' ),
+							'<a href="' . esc_url( $settings_url ) . '">' . esc_html__( 'Settings', 'graphql-strava-activities' ) . '</a>'
+						);
+						?>
+					</p>
+				<?php endif; ?>
+
+				<details style="margin-top: 12px;">
+					<summary style="cursor: pointer; font-size: 13px; color: #646970;"><?php esc_html_e( 'Manual setup (advanced)', 'graphql-strava-activities' ); ?></summary>
+					<ol style="font-size: 14px; line-height: 1.8; margin-top: 8px;">
+						<li>
+							<?php esc_html_e( 'Visit the following URL in your browser (replace YOUR_CLIENT_ID):', 'graphql-strava-activities' ); ?>
+							<br />
+							<code style="display: block; padding: 8px; margin: 8px 0; background: #f0f0f1; font-size: 13px; word-break: break-all;">https://www.strava.com/oauth/authorize?client_id=YOUR_CLIENT_ID&amp;response_type=code&amp;redirect_uri=http://localhost&amp;scope=read,activity:read_all&amp;approval_prompt=force</code>
+						</li>
+						<li><?php esc_html_e( 'Authorise the app. You will be redirected to localhost with a "code" parameter in the URL.', 'graphql-strava-activities' ); ?></li>
+						<li>
+							<?php esc_html_e( 'Exchange the code for tokens using curl or any HTTP client:', 'graphql-strava-activities' ); ?>
+							<br />
+							<code style="display: block; padding: 8px; margin: 8px 0; background: #f0f0f1; font-size: 13px; word-break: break-all;">curl -X POST https://www.strava.com/oauth/token -d client_id=YOUR_CLIENT_ID -d client_secret=YOUR_CLIENT_SECRET -d code=YOUR_CODE -d grant_type=authorization_code</code>
+						</li>
+						<li><?php esc_html_e( 'The response contains your access_token, refresh_token, and expires_at. Enter them in the plugin settings.', 'graphql-strava-activities' ); ?></li>
+					</ol>
+				</details>
+
+				<p style="font-size: 13px; color: #646970; margin-top: 8px;">
 					<?php esc_html_e( 'The plugin automatically refreshes your access token when it expires — you only need to do this once.', 'graphql-strava-activities' ); ?>
 				</p>
 			</div>

--- a/includes/oauth.php
+++ b/includes/oauth.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * OAuth callback handler for Strava authorization.
+ *
+ * Handles the Strava OAuth redirect, exchanges the authorization code
+ * for access/refresh tokens, and persists them via the existing
+ * encryption infrastructure.
+ *
+ * @package WPGraphQL\Strava
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Strava OAuth authorization endpoint.
+ *
+ * @var string
+ */
+define( 'WPGRAPHQL_STRAVA_OAUTH_AUTHORIZE_URL', 'https://www.strava.com/oauth/authorize' );
+
+/**
+ * Strava OAuth token endpoint.
+ *
+ * @var string
+ */
+define( 'WPGRAPHQL_STRAVA_OAUTH_TOKEN_URL', 'https://www.strava.com/oauth/token' );
+
+add_action( 'admin_init', 'wpgraphql_strava_handle_oauth_callback' );
+
+/**
+ * Handle the OAuth callback from Strava.
+ *
+ * Listens for the `strava_oauth_code` query parameter on the Getting Started
+ * page. Verifies the state nonce, exchanges the code for tokens, and saves them.
+ *
+ * @return void
+ */
+function wpgraphql_strava_handle_oauth_callback(): void {
+	// Only process on our admin page with the oauth code present.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- state parameter serves as nonce.
+	if ( ! isset( $_GET['strava_oauth_code'] ) || ! isset( $_GET['state'] ) ) {
+		return;
+	}
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	// Verify the state parameter (CSRF protection).
+	$state = sanitize_text_field( wp_unslash( $_GET['state'] ) );
+	if ( ! wp_verify_nonce( $state, 'wpgraphql_strava_oauth' ) ) {
+		set_transient(
+			'wpgraphql_strava_admin_notice',
+			[
+				'type'    => 'error',
+				'message' => __( 'OAuth failed: invalid state parameter. Please try again.', 'graphql-strava-activities' ),
+			],
+			30
+		);
+		wp_safe_redirect( admin_url( 'admin.php?page=wpgraphql-strava-settings' ) );
+		exit;
+	}
+
+	$code          = sanitize_text_field( wp_unslash( $_GET['strava_oauth_code'] ) );
+	$client_id     = get_option( 'wpgraphql_strava_client_id', '' );
+	$client_secret = wpgraphql_strava_get_option( 'wpgraphql_strava_client_secret' );
+
+	if ( empty( $client_id ) || empty( $client_secret ) ) {
+		set_transient(
+			'wpgraphql_strava_admin_notice',
+			[
+				'type'    => 'error',
+				'message' => __( 'OAuth failed: Client ID and Client Secret must be saved first.', 'graphql-strava-activities' ),
+			],
+			30
+		);
+		wp_safe_redirect( admin_url( 'admin.php?page=wpgraphql-strava-settings' ) );
+		exit;
+	}
+
+	// Exchange the authorization code for tokens.
+	$response = wp_remote_post(
+		WPGRAPHQL_STRAVA_OAUTH_TOKEN_URL,
+		[
+			'timeout' => 15,
+			'body'    => [
+				'client_id'     => $client_id,
+				'client_secret' => $client_secret,
+				'code'          => $code,
+				'grant_type'    => 'authorization_code',
+			],
+		]
+	);
+
+	if ( is_wp_error( $response ) ) {
+		set_transient(
+			'wpgraphql_strava_admin_notice',
+			[
+				'type'    => 'error',
+				'message' => __( 'OAuth failed: ', 'graphql-strava-activities' ) . $response->get_error_message(),
+			],
+			30
+		);
+		wp_safe_redirect( admin_url( 'admin.php?page=wpgraphql-strava-settings' ) );
+		exit;
+	}
+
+	$status_code = wp_remote_retrieve_response_code( $response );
+	$data        = json_decode( wp_remote_retrieve_body( $response ), true );
+
+	if ( 200 !== $status_code || ! is_array( $data ) || empty( $data['access_token'] ) ) {
+		$error_detail = '';
+		if ( is_array( $data ) && ! empty( $data['message'] ) ) {
+			$error_detail = sanitize_text_field( $data['message'] );
+		}
+
+		set_transient(
+			'wpgraphql_strava_admin_notice',
+			[
+				'type'    => 'error',
+				'message' => sprintf(
+					/* translators: 1: HTTP status code, 2: Error detail */
+					__( 'OAuth token exchange failed (HTTP %1$d). %2$s', 'graphql-strava-activities' ),
+					$status_code,
+					$error_detail
+				),
+			],
+			30
+		);
+		wp_safe_redirect( admin_url( 'admin.php?page=wpgraphql-strava-settings' ) );
+		exit;
+	}
+
+	// Persist tokens (encrypted at rest when key is configured).
+	wpgraphql_strava_update_option( 'wpgraphql_strava_access_token', sanitize_text_field( $data['access_token'] ) );
+
+	if ( ! empty( $data['refresh_token'] ) ) {
+		wpgraphql_strava_update_option( 'wpgraphql_strava_refresh_token', sanitize_text_field( $data['refresh_token'] ) );
+	}
+
+	if ( ! empty( $data['expires_at'] ) ) {
+		update_option( 'wpgraphql_strava_token_expires_at', (int) $data['expires_at'] );
+	}
+
+	// Trigger an immediate sync so the user sees activities right away.
+	delete_transient( 'wpgraphql_strava_activities' );
+	$activities = wpgraphql_strava_get_cached_activities( 1 );
+
+	if ( ! empty( $activities ) ) {
+		set_transient(
+			'wpgraphql_strava_admin_notice',
+			[
+				'type'    => 'success',
+				'message' => sprintf(
+					/* translators: %d: Number of activities synced */
+					__( 'Connected to Strava! Synced %d activities.', 'graphql-strava-activities' ),
+					count( wpgraphql_strava_get_cached_activities( 0 ) )
+				),
+			],
+			30
+		);
+	} else {
+		set_transient(
+			'wpgraphql_strava_admin_notice',
+			[
+				'type'    => 'success',
+				'message' => __( 'Connected to Strava! No activities found yet — they will appear after your next workout.', 'graphql-strava-activities' ),
+			],
+			30
+		);
+	}
+
+	wp_safe_redirect( admin_url( 'admin.php?page=wpgraphql-strava-settings' ) );
+	exit;
+}
+
+/**
+ * Build the Strava OAuth authorization URL.
+ *
+ * Uses the plugin's own callback URL as the redirect_uri. The state
+ * parameter is a nonce for CSRF protection.
+ *
+ * @return string Authorization URL, or empty string if Client ID is not configured.
+ */
+function wpgraphql_strava_get_oauth_url(): string {
+	$client_id = get_option( 'wpgraphql_strava_client_id', '' );
+
+	if ( empty( $client_id ) ) {
+		return '';
+	}
+
+	$state        = wp_create_nonce( 'wpgraphql_strava_oauth' );
+	$redirect_uri = wpgraphql_strava_get_oauth_redirect_uri();
+
+	return add_query_arg(
+		[
+			'client_id'       => $client_id,
+			'response_type'   => 'code',
+			'redirect_uri'    => $redirect_uri,
+			'scope'           => 'read,activity:read_all',
+			'approval_prompt' => 'force',
+			'state'           => $state,
+		],
+		WPGRAPHQL_STRAVA_OAUTH_AUTHORIZE_URL
+	);
+}
+
+/**
+ * Get the OAuth redirect URI that Strava will send the user back to.
+ *
+ * This must match the "Authorization Callback Domain" configured in
+ * the Strava API application settings.
+ *
+ * @return string Redirect URI.
+ */
+function wpgraphql_strava_get_oauth_redirect_uri(): string {
+	return admin_url( 'admin.php?page=wpgraphql-strava-settings' );
+}


### PR DESCRIPTION
## Summary
- Adds `includes/oauth.php` with OAuth callback handler and URL builder
- "Connect with Strava" button on Settings page (shown when no token exists)
- Getting Started page shows contextual state: connected, connect button, or "enter Client ID first"
- Manual curl method preserved under collapsible "Manual setup (advanced)" section
- CSRF protection via WordPress nonce in the OAuth `state` parameter
- Automatic first sync after successful authorization

## How it works
1. User saves Client ID + Secret on Settings page
2. Clicks "Connect with Strava" button
3. Strava redirects back with `?code=...&state=...`
4. Plugin intercepts the redirect, exchanges code for tokens, saves them (encrypted if configured)
5. Triggers immediate activity sync, redirects to Settings with success message

## Test plan
- [x] `composer lint` — clean
- [x] `composer analyse` — no errors
- [x] `composer test` — 65 tests, 248 assertions pass
- [ ] Manual test: save Client ID/Secret, click Connect, verify OAuth flow completes

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)