### PR TITLE
feat: pagination, speed conversion, sync hooks, copy buttons, validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Connection Status card on Settings page with token expiry date and status indicator
 - Token health admin notice on plugin pages when credentials are missing or expired
 - Specific API error descriptions (401, 403, 429, 5xx) replacing generic "API returned status" messages
+- `offset` argument for GraphQL `stravaActivities` query for pagination
+- `speedUnit` GraphQL field ("mph" or "km/h") matching the distance unit setting
+- Speed fields (`averageSpeed`, `maxSpeed`) now converted to match distance unit (mph or km/h)
+- `wpgraphql_strava_before_sync` and `wpgraphql_strava_after_sync` action hooks
+- `wpgraphql_strava_activities_to_fetch` filter (default 200, max 200)
+- Copy-to-clipboard buttons on GraphQL query examples in Getting Started page
+- Input validation: `first` clamped to 0-200, `offset` validated, `type` sanitized
 
 ## [1.0.3] - 2026-03-15
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ that depend on them. The bootstrap file handles this.
 
 ## GraphQL Fields
 
-The `StravaActivity` type exposes 21 fields. All come from the Strava list endpoint
+The `StravaActivity` type exposes 22 fields. All come from the Strava list endpoint
 (no extra API calls needed):
 
 | Field | Type | Source |
@@ -95,8 +95,9 @@ The `StravaActivity` type exposes 21 fields. All come from the Strava list endpo
 | stravaUrl | String | `id` (constructed URL) |
 | photoUrl | String | `photos.primary.urls` |
 | elevationGain | Float | `total_elevation_gain` (metres) |
-| averageSpeed | Float | `average_speed` (m/s) |
-| maxSpeed | Float | `max_speed` (m/s) |
+| speedUnit | String | Setting ("mph" or "km/h") |
+| averageSpeed | Float | `average_speed` (converted to mph/km/h) |
+| maxSpeed | Float | `max_speed` (converted to mph/km/h) |
 | averageHeartrate | Float | `average_heartrate` (nullable) |
 | maxHeartrate | Int | `max_heartrate` (nullable) |
 | calories | Float | `kilojoules` × 0.239 (nullable) |

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -1117,35 +1117,58 @@ function wpgraphql_strava_render_guide_page(): void {
 			<!-- GraphQL Examples -->
 			<div class="card" style="max-width: 800px; padding: 16px 24px;">
 				<h2 style="margin-top: 8px;"><?php esc_html_e( 'GraphQL Query Examples', 'graphql-strava-activities' ); ?></h2>
+				<p style="font-size: 13px; color: #646970;"><?php esc_html_e( 'Click "Copy" to copy a query to your clipboard, then paste it into WPGraphiQL.', 'graphql-strava-activities' ); ?></p>
 
 				<h3><?php esc_html_e( 'Fetch all activities with full data', 'graphql-strava-activities' ); ?></h3>
-				<pre style="background: #f0f0f1; padding: 12px; overflow-x: auto; font-size: 13px;">{
+				<div style="position: relative;">
+					<pre class="wpgraphql-strava-query" style="background: #f0f0f1; padding: 12px; overflow-x: auto; font-size: 13px;">{
   stravaActivities {
-	title distance duration date type unit
+	title distance duration date type unit speedUnit
 	svgMap stravaUrl photoUrl
 	elevationGain averageSpeed maxSpeed
 	averageHeartrate maxHeartrate calories
 	kudosCount commentCount city country isPrivate
   }
 }</pre>
+					<button type="button" class="button button-small wpgraphql-strava-copy" style="position:absolute;top:8px;right:8px;"><?php esc_html_e( 'Copy', 'graphql-strava-activities' ); ?></button>
+				</div>
 
 				<h3><?php esc_html_e( 'Fetch latest 5 rides with performance data', 'graphql-strava-activities' ); ?></h3>
-				<pre style="background: #f0f0f1; padding: 12px; overflow-x: auto; font-size: 13px;">{
+				<div style="position: relative;">
+					<pre class="wpgraphql-strava-query" style="background: #f0f0f1; padding: 12px; overflow-x: auto; font-size: 13px;">{
   stravaActivities(first: 5, type: "Ride") {
 	title distance duration svgMap
 	elevationGain averageSpeed calories
   }
 }</pre>
+					<button type="button" class="button button-small wpgraphql-strava-copy" style="position:absolute;top:8px;right:8px;"><?php esc_html_e( 'Copy', 'graphql-strava-activities' ); ?></button>
+				</div>
 
 				<h3><?php esc_html_e( 'Fetch runs with heart rate and location', 'graphql-strava-activities' ); ?></h3>
-				<pre style="background: #f0f0f1; padding: 12px; overflow-x: auto; font-size: 13px;">{
+				<div style="position: relative;">
+					<pre class="wpgraphql-strava-query" style="background: #f0f0f1; padding: 12px; overflow-x: auto; font-size: 13px;">{
   stravaActivities(type: "Run") {
 	title distance duration date
 	averageHeartrate maxHeartrate
 	city country photoUrl stravaUrl
   }
 }</pre>
+					<button type="button" class="button button-small wpgraphql-strava-copy" style="position:absolute;top:8px;right:8px;"><?php esc_html_e( 'Copy', 'graphql-strava-activities' ); ?></button>
+				</div>
 			</div>
+
+			<script>
+			document.addEventListener( 'click', function( e ) {
+				if ( ! e.target.classList.contains( 'wpgraphql-strava-copy' ) ) return;
+				var pre = e.target.parentElement.querySelector( '.wpgraphql-strava-query' );
+				if ( ! pre ) return;
+				navigator.clipboard.writeText( pre.textContent ).then( function() {
+					var btn = e.target;
+					btn.textContent = '<?php echo esc_js( __( 'Copied!', 'graphql-strava-activities' ) ); ?>';
+					setTimeout( function() { btn.textContent = '<?php echo esc_js( __( 'Copy', 'graphql-strava-activities' ) ); ?>'; }, 2000 );
+				} );
+			} );
+			</script>
 
 			<!-- StravaActivity Fields -->
 			<div class="card" style="max-width: 800px; padding: 16px 24px;">

--- a/includes/cache.php
+++ b/includes/cache.php
@@ -50,8 +50,17 @@ function wpgraphql_strava_get_cached_activities( int $count = 0 ): array {
 		return [];
 	}
 
-	// Fetch maximum activities from Strava (1 API call).
-	$raw_activities = wpgraphql_strava_fetch_activities( 200 );
+	/**
+	 * Filters the number of activities to fetch from Strava.
+	 *
+	 * @param int $fetch_count Number of activities to request (max 200).
+	 */
+	$fetch_count = min( (int) apply_filters( 'wpgraphql_strava_activities_to_fetch', 200 ), 200 );
+
+	/** Fires before activities are fetched from the Strava API. */
+	do_action( 'wpgraphql_strava_before_sync' );
+
+	$raw_activities = wpgraphql_strava_fetch_activities( $fetch_count );
 
 	if ( empty( $raw_activities ) ) {
 		return [];
@@ -97,6 +106,14 @@ function wpgraphql_strava_get_cached_activities( int $count = 0 ): array {
 
 	set_transient( WPGRAPHQL_STRAVA_CACHE_KEY, $activities, $ttl );
 	update_option( 'wpgraphql_strava_last_sync', time() );
+
+	/**
+	 * Fires after activities have been fetched and cached.
+	 *
+	 * @param array<int, array<string, mixed>> $activities Processed activities.
+	 * @param int                              $raw_count  Number of raw activities from Strava.
+	 */
+	do_action( 'wpgraphql_strava_after_sync', $activities, count( $raw_activities ) );
 
 	return $count > 0 ? array_slice( $activities, 0, $count ) : $activities;
 }
@@ -146,11 +163,22 @@ function wpgraphql_strava_process_activities( array $raw_activities ): array {
 			continue;
 		}
 
-		// Distance conversion.
-		$distance_raw = isset( $activity['distance'] ) ? (float) $activity['distance'] : 0.0;
-		$distance     = 'km' === $unit
-			? round( $distance_raw / 1000, 2 )
-			: round( $distance_raw / 1609.344, 2 );
+		// Distance and speed conversion.
+		$distance_raw    = isset( $activity['distance'] ) ? (float) $activity['distance'] : 0.0;
+		$avg_speed_raw   = isset( $activity['average_speed'] ) ? (float) $activity['average_speed'] : 0.0;
+		$max_speed_raw   = isset( $activity['max_speed'] ) ? (float) $activity['max_speed'] : 0.0;
+
+		if ( 'km' === $unit ) {
+			$distance  = round( $distance_raw / 1000, 2 );
+			$avg_speed = round( $avg_speed_raw * 3.6, 2 );      // m/s → km/h.
+			$max_speed = round( $max_speed_raw * 3.6, 2 );
+			$speed_unit = 'km/h';
+		} else {
+			$distance  = round( $distance_raw / 1609.344, 2 );
+			$avg_speed = round( $avg_speed_raw * 2.23694, 2 );  // m/s → mph.
+			$max_speed = round( $max_speed_raw * 2.23694, 2 );
+			$speed_unit = 'mph';
+		}
 
 		$moving_time = isset( $activity['moving_time'] ) ? (int) $activity['moving_time'] : 0;
 
@@ -173,9 +201,10 @@ function wpgraphql_strava_process_activities( array $raw_activities ): array {
 			'type'           => sanitize_text_field( $type ),
 			'photoUrl'       => esc_url_raw( $photo_url ),
 			'unit'           => $unit,
+			'speedUnit'      => $speed_unit,
 			'elevationGain'  => isset( $activity['total_elevation_gain'] ) ? round( (float) $activity['total_elevation_gain'], 1 ) : 0.0,
-			'averageSpeed'   => isset( $activity['average_speed'] ) ? round( (float) $activity['average_speed'], 2 ) : 0.0,
-			'maxSpeed'       => isset( $activity['max_speed'] ) ? round( (float) $activity['max_speed'], 2 ) : 0.0,
+			'averageSpeed'   => $avg_speed,
+			'maxSpeed'       => $max_speed,
 			'averageHeartrate' => isset( $activity['average_heartrate'] ) ? round( (float) $activity['average_heartrate'] ) : null,
 			'maxHeartrate'   => isset( $activity['max_heartrate'] ) ? (int) $activity['max_heartrate'] : null,
 			'calories'       => isset( $activity['kilojoules'] ) ? round( (float) $activity['kilojoules'] * 0.239006, 0 ) : null,

--- a/includes/graphql.php
+++ b/includes/graphql.php
@@ -67,13 +67,17 @@ function wpgraphql_strava_register_types(): void {
 					'type'        => 'Float',
 					'description' => __( 'Total elevation gain in metres.', 'graphql-strava-activities' ),
 				],
+				'speedUnit'        => [
+					'type'        => 'String',
+					'description' => __( 'Speed unit — "mph" or "km/h".', 'graphql-strava-activities' ),
+				],
 				'averageSpeed'     => [
 					'type'        => 'Float',
-					'description' => __( 'Average speed in metres per second.', 'graphql-strava-activities' ),
+					'description' => __( 'Average speed in mph or km/h based on settings.', 'graphql-strava-activities' ),
 				],
 				'maxSpeed'         => [
 					'type'        => 'Float',
-					'description' => __( 'Maximum speed in metres per second.', 'graphql-strava-activities' ),
+					'description' => __( 'Maximum speed in mph or km/h based on settings.', 'graphql-strava-activities' ),
 				],
 				'averageHeartrate' => [
 					'type'        => 'Float',
@@ -122,22 +126,31 @@ function wpgraphql_strava_register_types(): void {
 			'type'        => [ 'list_of' => 'StravaActivity' ],
 			'description' => __( 'Recent Strava activities with route maps.', 'graphql-strava-activities' ),
 			'args'        => [
-				'first' => [
+				'first'  => [
 					'type'         => 'Int',
-					'description'  => __( 'Number of activities to return. 0 = all cached.', 'graphql-strava-activities' ),
+					'description'  => __( 'Number of activities to return (0 = all, max 200).', 'graphql-strava-activities' ),
 					'defaultValue' => 0,
 				],
-				'type'  => [
+				'offset' => [
+					'type'         => 'Int',
+					'description'  => __( 'Number of activities to skip before returning results.', 'graphql-strava-activities' ),
+					'defaultValue' => 0,
+				],
+				'type'   => [
 					'type'        => 'String',
 					'description' => __( 'Filter by activity type (e.g. "Ride", "Run").', 'graphql-strava-activities' ),
 				],
 			],
 			'resolve'     => static function ( $root, array $args ): array {
-				$count      = max( (int) ( $args['first'] ?? 0 ), 0 );
-				$activities = wpgraphql_strava_get_cached_activities( $count );
+				// Validate and clamp arguments.
+				$count  = min( max( (int) ( $args['first'] ?? 0 ), 0 ), 200 );
+				$offset = max( (int) ( $args['offset'] ?? 0 ), 0 );
 
-				// Client-side type filter.
-				$type_filter = $args['type'] ?? '';
+				// Fetch all cached activities (filtering/slicing done below).
+				$activities = wpgraphql_strava_get_cached_activities( 0 );
+
+				// Type filter.
+				$type_filter = sanitize_text_field( $args['type'] ?? '' );
 				if ( ! empty( $type_filter ) ) {
 					$activities = array_values(
 						array_filter(
@@ -145,11 +158,11 @@ function wpgraphql_strava_register_types(): void {
 							static fn( array $a ): bool => ( $a['type'] ?? '' ) === $type_filter
 						)
 					);
+				}
 
-					// Re-apply count limit after filtering.
-					if ( $count > 0 ) {
-						$activities = array_slice( $activities, 0, $count );
-					}
+				// Apply offset and count.
+				if ( $offset > 0 || $count > 0 ) {
+					$activities = array_slice( $activities, $offset, $count > 0 ? $count : null );
 				}
 
 				return $activities;

--- a/tests/Integration/GraphQLTest.php
+++ b/tests/Integration/GraphQLTest.php
@@ -310,6 +310,7 @@ class GraphQLTest extends TestCase {
 			'type',
 			'photoUrl',
 			'unit',
+			'speedUnit',
 			'elevationGain',
 			'averageSpeed',
 			'maxSpeed',
@@ -324,7 +325,7 @@ class GraphQLTest extends TestCase {
 			'poweredByStrava',
 		];
 
-		$this->assertCount( 21, $fields, 'StravaActivity should have exactly 21 fields.' );
+		$this->assertCount( 22, $fields, 'StravaActivity should have exactly 22 fields.' );
 
 		foreach ( $expected_fields as $field_name ) {
 			$this->assertArrayHasKey( $field_name, $fields, "Missing field: {$field_name}" );


### PR DESCRIPTION
## Summary
- **#84** — `wpgraphql_strava_activities_to_fetch` filter (configurable, max 200)
- **#85** — Copy-to-clipboard buttons on GraphQL query examples in Getting Started
- **#89** — `wpgraphql_strava_before_sync` / `wpgraphql_strava_after_sync` action hooks
- **#90** — Speed fields converted to mph/km/h matching distance unit + new `speedUnit` field (22 fields total)
- **#91** — `offset` argument for GraphQL pagination
- **#95** — `first` clamped 0-200, `offset` validated, `type` sanitized

## Test plan
- [x] All checks pass (lint, analyse, 65 tests)

Closes #84, #85, #89, #90, #91, #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)