### PR TITLE
feat: REST API, SVG thumbnails, PCP in CI, GitHub topics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,40 @@ jobs:
 
       - name: Run tests
         run: composer test
+
+  plugin-check:
+    name: Plugin Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: openssl, mbstring
+          coverage: none
+
+      - name: Setup WordPress
+        run: |
+          mkdir -p /tmp/wp && cd /tmp/wp
+          curl -sO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+          chmod +x wp-cli.phar
+          ./wp-cli.phar core download --skip-content
+          ./wp-cli.phar config create --dbname=wp_test --dbuser=root --dbpass=root --dbhost=127.0.0.1 --skip-check
+          sudo systemctl start mysql
+          mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS wp_test;"
+          ./wp-cli.phar core install --url=localhost --title=Test --admin_user=admin --admin_password=admin --admin_email=admin@example.com --skip-email
+
+      - name: Install Plugin Check
+        run: cd /tmp/wp && ./wp-cli.phar plugin install plugin-check --activate
+
+      - name: Build and install plugin
+        run: |
+          git archive --format=zip --prefix=graphql-strava-activities/ HEAD -o /tmp/graphql-strava-activities.zip
+          cd /tmp/wp && ./wp-cli.phar plugin install /tmp/graphql-strava-activities.zip --activate
+
+      - name: Run Plugin Check
+        run: cd /tmp/wp && ./wp-cli.phar plugin check graphql-strava-activities --format=json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wpgraphql_strava_activities_to_fetch` filter (default 200, max 200)
 - Copy-to-clipboard buttons on GraphQL query examples in Getting Started page
 - Input validation: `first` clamped to 0-200, `offset` validated, `type` sanitized
+- REST API endpoint: `GET /wp-json/wpgraphql-strava/v1/activities` with `count`, `offset`, `type` params
+- SVG route thumbnails in admin Activities list table (replaces checkmarks)
+- Plugin Check (PCP) job in CI workflow
+- GitHub topics for repository discoverability
 
 ## [1.0.3] - 2026-03-15
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ includes/
 ├── admin.php                  # Settings page + Getting Started + Preview + Activities
 ├── graphql.php                # StravaActivity type + stravaActivities query
 ├── oauth.php                  # Strava OAuth callback handler (one-click connect)
+├── rest-api.php               # REST API endpoint (/wp-json/wpgraphql-strava/v1/activities)
 ├── shortcodes.php             # WordPress shortcodes for non-headless sites
 ├── updater.php                # Self-hosted update checker via GitHub Releases API
 └── class-wpgraphql-strava-activities-list-table.php  # WP_List_Table for Activities page

--- a/graphql-strava-activities.php
+++ b/graphql-strava-activities.php
@@ -110,6 +110,7 @@ function wpgraphql_strava_init(): void {
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/admin.php';
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/class-wpgraphql-strava-activities-list-table.php';
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/graphql.php';
+	require_once WPGRAPHQL_STRAVA_DIR . 'includes/rest-api.php';
 	require_once WPGRAPHQL_STRAVA_DIR . 'includes/shortcodes.php';
 }
 

--- a/includes/class-wpgraphql-strava-activities-list-table.php
+++ b/includes/class-wpgraphql-strava-activities-list-table.php
@@ -195,15 +195,19 @@ class WPGRAPHQL_Strava_Activities_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Route column — shows check or dash.
+	 * Route column — shows SVG thumbnail or dash.
 	 *
 	 * @param array<string, mixed> $item Activity data.
 	 * @return string Cell content.
 	 */
 	public function column_route( array $item ): string {
-		return ! empty( $item['svgMap'] )
-			? '<span style="color:#16a34a;" title="' . esc_attr__( 'Has route map', 'graphql-strava-activities' ) . '">&#10003;</span>'
-			: '<span style="color:#9ca3af;">—</span>';
+		if ( empty( $item['svgMap'] ) ) {
+			return '<span style="color:#9ca3af;">—</span>';
+		}
+
+		return '<div style="width:60px;height:40px;overflow:hidden;">'
+			. wp_kses( $item['svgMap'], wpgraphql_strava_allowed_svg_tags() )
+			. '</div>';
 	}
 
 	/**

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * REST API endpoint for Strava activities.
+ *
+ * Registers a public endpoint so non-headless sites or REST-based
+ * frontends can access cached Strava activity data.
+ *
+ * @package WPGraphQL\Strava
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'rest_api_init', 'wpgraphql_strava_register_rest_routes' );
+
+/**
+ * Register the REST API route.
+ *
+ * @return void
+ */
+function wpgraphql_strava_register_rest_routes(): void {
+	register_rest_route(
+		'wpgraphql-strava/v1',
+		'/activities',
+		[
+			'methods'             => 'GET',
+			'callback'            => 'wpgraphql_strava_rest_activities',
+			'permission_callback' => '__return_true',
+			'args'                => [
+				'count'  => [
+					'type'              => 'integer',
+					'default'           => 0,
+					'minimum'           => 0,
+					'maximum'           => 200,
+					'sanitize_callback' => 'absint',
+				],
+				'offset' => [
+					'type'              => 'integer',
+					'default'           => 0,
+					'minimum'           => 0,
+					'sanitize_callback' => 'absint',
+				],
+				'type'   => [
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+			],
+		]
+	);
+}
+
+/**
+ * Handle the /activities REST request.
+ *
+ * @param \WP_REST_Request $request REST request.
+ * @return \WP_REST_Response Activities response.
+ */
+function wpgraphql_strava_rest_activities( \WP_REST_Request $request ): \WP_REST_Response {
+	$count      = (int) $request->get_param( 'count' );
+	$offset     = (int) $request->get_param( 'offset' );
+	$type       = (string) $request->get_param( 'type' );
+	$activities = wpgraphql_strava_get_cached_activities( 0 );
+
+	// Type filter.
+	if ( ! empty( $type ) ) {
+		$activities = array_values(
+			array_filter(
+				$activities,
+				static fn( array $a ): bool => ( $a['type'] ?? '' ) === $type
+			)
+		);
+	}
+
+	$total = count( $activities );
+
+	// Apply offset and count.
+	if ( $offset > 0 || $count > 0 ) {
+		$activities = array_slice( $activities, $offset, $count > 0 ? $count : null );
+	}
+
+	$response = new \WP_REST_Response( $activities, 200 );
+	$response->header( 'X-WP-Total', (string) $total );
+
+	return $response;
+}


### PR DESCRIPTION
## Summary
- **#88** — Added 8 GitHub topics for discoverability
- **#92** — REST API endpoint `GET /wp-json/wpgraphql-strava/v1/activities` with `count`, `offset`, `type` params and `X-WP-Total` header
- **#94** — Plugin Check (PCP) CI job: builds archive, installs WP + PCP, runs check
- **#96** — SVG route map thumbnails (60x40) in Activities list table replacing checkmarks

## Test plan
- [x] All checks pass (lint, analyse, 65 tests)

Closes #88, #92, #94, #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)