### PR TITLE
docs: update all documentation and add doc drift CI check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,6 +188,47 @@ jobs:
             echo "$WRONG"
           fi
 
+      - name: Verify documentation consistency
+        run: |
+          FAIL=0
+
+          # Count GraphQL fields in the StravaActivity type definition.
+          # Fields are at 4-tab indent ending with "=> [" before the args section.
+          CODE_FIELDS=$(sed -n '/register_graphql_object_type/,/register_graphql_field/p' includes/graphql.php | grep -cP "^\t{4}'[a-z]" || echo 0)
+          # Count in docs/fields.md (table rows with backtick-wrapped field names).
+          DOC_FIELDS=$(grep -cP '^\| `\w+`' docs/fields.md || echo 0)
+
+          echo "GraphQL fields in code: $CODE_FIELDS"
+          echo "Fields documented: $DOC_FIELDS"
+
+          if [ "$CODE_FIELDS" != "$DOC_FIELDS" ]; then
+            echo "::error::Field count mismatch: graphql.php has $CODE_FIELDS fields but docs/fields.md documents $DOC_FIELDS"
+            FAIL=1
+          fi
+
+          # Count includes/ PHP files vs architecture.md entries.
+          CODE_INCLUDES=$(find includes/ -name "*.php" | wc -l)
+          DOC_INCLUDES=$(grep -cP '├──|└──' docs/architecture.md || echo 0)
+
+          echo "PHP files in includes/: $CODE_INCLUDES"
+          echo "Files in architecture.md: $DOC_INCLUDES"
+
+          if [ "$CODE_INCLUDES" != "$DOC_INCLUDES" ]; then
+            echo "::error::Architecture doc mismatch: includes/ has $CODE_INCLUDES files but docs/architecture.md lists $DOC_INCLUDES"
+            FAIL=1
+          fi
+
+          # Verify CLAUDE.md field count matches code.
+          CLAUDE_FIELDS=$(grep -oP 'exposes \K\d+' CLAUDE.md || echo 0)
+          echo "CLAUDE.md states: $CLAUDE_FIELDS fields"
+
+          if [ "$CLAUDE_FIELDS" != "$CODE_FIELDS" ]; then
+            echo "::error::CLAUDE.md says $CLAUDE_FIELDS fields but code has $CODE_FIELDS"
+            FAIL=1
+          fi
+
+          exit $FAIL
+
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ All filters use the `wpgraphql_strava_` prefix:
 | `wpgraphql_strava_svg_attributes` | `[]` | Extra SVG element attributes |
 | `wpgraphql_strava_activities` | — | Filter activities before caching |
 | `wpgraphql_strava_activity_types` | `[]` (all) | Whitelist of allowed types |
+| `wpgraphql_strava_activities_to_fetch` | `200` | Max activities to sync (clamped to 200) |
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GraphQL Strava Activities
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Tests](https://github.com/shawnazar/graphql-strava-activities/actions/workflows/test.yml/badge.svg)](https://github.com/shawnazar/graphql-strava-activities/actions/workflows/test.yml)
 [![PHP 8.2+](https://img.shields.io/badge/PHP-8.2%2B-8892BF.svg)](https://www.php.net/)
 [![WordPress 6.0+](https://img.shields.io/badge/WordPress-6.0%2B-21759B.svg)](https://wordpress.org/)
 [![WPGraphQL 2.0+](https://img.shields.io/badge/WPGraphQL-2.0%2B-4B32C3.svg)](https://www.wpgraphql.com/)
@@ -11,12 +12,15 @@ Compatible with Strava — a WordPress plugin that extends [WPGraphQL](https://w
 
 ## Features
 
-- **GraphQL API** — Query Strava activities with filtering by type and count
+- **GraphQL API** — Query Strava activities with filtering, pagination (`offset`), and 22 fields
+- **REST API** — `GET /wp-json/wpgraphql-strava/v1/activities` for non-GraphQL frontends
 - **SVG Route Maps** — Server-rendered inline SVG from Strava polyline data
+- **One-Click OAuth** — "Connect with Strava" button handles token exchange automatically
 - **Activity Photos** — Primary photo fetching for your activities
 - **Caching** — Transient-based with configurable TTL and sync frequency
 - **Credential Encryption** — Optional AES-256-CBC at-rest encryption
-- **Extensible** — Filters for cache TTL, SVG appearance, activity types, and more
+- **Shortcode Generator** — Classic editor button for inserting Strava shortcodes
+- **Extensible** — Filters for cache TTL, SVG appearance, activity types, sync hooks, and more
 
 ## Requirements
 
@@ -43,9 +47,9 @@ Activate in WordPress, then visit **Strava** in the admin menu.
 
 ## Quick Start
 
-1. Create a Strava API application at [strava.com/settings/api](https://www.strava.com/settings/api)
-2. Enter your credentials in **Strava → Settings**
-3. Click **Resync Activities**
+1. Create a Strava API application at [strava.com/settings/api](https://www.strava.com/settings/api) (set callback domain to your site)
+2. Enter Client ID and Secret in **Strava → Settings** and click Save
+3. Click **"Connect with Strava"** — tokens are fetched and activities synced automatically
 4. Query via GraphQL:
 
 ```graphql
@@ -57,6 +61,7 @@ Activate in WordPress, then visit **Strava** in the admin menu.
     date
     type
     unit
+    speedUnit
     svgMap
     stravaUrl
     photoUrl
@@ -88,6 +93,7 @@ All filters use the `wpgraphql_strava_` prefix:
 | `wpgraphql_strava_svg_attributes` | `[]` | Extra SVG element attributes |
 | `wpgraphql_strava_activities` | — | Filter activities before caching |
 | `wpgraphql_strava_activity_types` | `[]` (all) | Whitelist of allowed types |
+| `wpgraphql_strava_activities_to_fetch` | `200` | Max activities to sync |
 
 ```php
 // Example: only show rides and runs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,12 +7,15 @@ graphql-strava-activities.php          # Bootstrap, dependency check, cron sched
 includes/
 ├── encryption.php             # Optional AES-256-CBC credential encryption
 ├── polyline.php               # Google encoded polyline → [lat, lng] decoder
-├── svg.php                    # [lat, lng] → inline SVG route map
+├── svg.php                    # [lat, lng] → inline SVG route map + wp_kses allowlist
 ├── api.php                    # Strava API client (activities, detail, token refresh)
 ├── cache.php                  # Transient caching, photo enrichment, normalization
+├── oauth.php                  # Strava OAuth callback handler (one-click connect)
 ├── admin.php                  # Settings page + Getting Started + Preview + Activities
 ├── graphql.php                # StravaActivity type + stravaActivities query
-├── shortcodes.php             # WordPress shortcodes for non-headless sites
+├── rest-api.php               # REST API endpoint (/wp-json/wpgraphql-strava/v1/activities)
+├── shortcodes.php             # WordPress shortcodes + classic editor generator button
+├── updater.php                # Self-hosted update checker via GitHub Releases API
 └── class-wpgraphql-strava-activities-list-table.php  # WP_List_Table for Activities page
 ```
 
@@ -20,15 +23,18 @@ includes/
 
 Load order matters — `encryption.php` and `polyline.php` must load before modules that depend on them. The bootstrap file (`graphql-strava-activities.php`) handles this:
 
-1. `encryption.php` — needed by api.php and admin.php for credential access
+1. `encryption.php` — needed by api.php, oauth.php, and admin.php for credential access
 2. `polyline.php` — needed by svg.php for polyline decoding
 3. `svg.php` — needed by cache.php for map generation
 4. `api.php` — needed by cache.php for Strava API calls
-5. `cache.php` — needed by graphql.php, admin.php, shortcodes.php
-6. `admin.php` — WordPress admin UI
-7. `graphql.php` — WPGraphQL type registration
-8. `shortcodes.php` — WordPress shortcodes
-9. `class-wpgraphql-strava-activities-list-table.php` — loaded by admin.php when needed
+5. `cache.php` — needed by graphql.php, admin.php, rest-api.php, shortcodes.php
+6. `oauth.php` — Strava OAuth callback handler (loaded before admin.php)
+7. `admin.php` — WordPress admin UI (test connection, resync, settings)
+8. `graphql.php` — WPGraphQL type registration (22 fields)
+9. `rest-api.php` — REST API endpoint registration
+10. `shortcodes.php` — WordPress shortcodes + editor generator button
+11. `class-wpgraphql-strava-activities-list-table.php` — loaded by admin.php when needed
+12. `updater.php` — loaded independently of WPGraphQL (always active)
 
 ## Data Flow
 
@@ -36,6 +42,7 @@ Load order matters — `encryption.php` and `polyline.php` must load before modu
 Strava API → api.php → cache.php → transient
                                        ↓
                               graphql.php (GraphQL queries)
+                              rest-api.php (REST API endpoint)
                               shortcodes.php (shortcode rendering)
                               admin.php (preview page, activities list)
 ```

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -1,6 +1,6 @@
 # Activity Fields
 
-The `StravaActivity` type exposes 21 fields. All data comes from the Strava list endpoint — no extra API calls needed per activity.
+The `StravaActivity` type exposes 22 fields. All data comes from the Strava list endpoint — no extra API calls needed per activity.
 
 ## Field Reference
 
@@ -12,12 +12,13 @@ The `StravaActivity` type exposes 21 fields. All data comes from the Strava list
 | `date` | String | Start date in ISO 8601 format | `start_date` |
 | `type` | String | Activity type (Ride, Run, Walk, etc.) | `type` |
 | `unit` | String | Distance unit — "mi" or "km" | Setting |
+| `speedUnit` | String | Speed unit — "mph" or "km/h" | Setting |
 | `svgMap` | String | Inline SVG route map markup | `map.summary_polyline` |
 | `stravaUrl` | String | Link to the activity on Strava | Constructed from `id` |
 | `photoUrl` | String | Primary activity photo URL (nullable) | `photos.primary.urls` |
 | `elevationGain` | Float | Total elevation gain in metres | `total_elevation_gain` |
-| `averageSpeed` | Float | Average speed in m/s | `average_speed` |
-| `maxSpeed` | Float | Maximum speed in m/s | `max_speed` |
+| `averageSpeed` | Float | Average speed in mph or km/h (based on settings) | `average_speed` |
+| `maxSpeed` | Float | Maximum speed in mph or km/h (based on settings) | `max_speed` |
 | `averageHeartrate` | Float | Average heart rate in bpm (nullable) | `average_heartrate` |
 | `maxHeartrate` | Int | Max heart rate in bpm (nullable) | `max_heartrate` |
 | `calories` | Float | Estimated calories burned (nullable) | `kilojoules` × 0.239 |
@@ -36,14 +37,16 @@ These fields may return `null` if the data is unavailable:
 - `averageHeartrate` / `maxHeartrate` — requires a heart rate monitor
 - `calories` — only available for certain activity types
 
-## Distance Units
+## Distance & Speed Units
 
-The `distance` field is automatically converted based on the **Display Unit** setting:
+The `distance`, `averageSpeed`, and `maxSpeed` fields are automatically converted based on the **Display Unit** setting:
 
-- **Miles** (`mi`) — default
-- **Kilometres** (`km`)
+| Setting | Distance | Speed | Unit Fields |
+|---|---|---|---|
+| **Miles** (default) | miles | mph | `unit: "mi"`, `speedUnit: "mph"` |
+| **Kilometres** | km | km/h | `unit: "km"`, `speedUnit: "km/h"` |
 
-The `unit` field tells you which unit is in use, so your frontend can display the correct label.
+The `unit` and `speedUnit` fields tell your frontend which labels to display.
 
 ## Activity Types
 

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -107,14 +107,61 @@ add_filter( 'wpgraphql_strava_activity_types', function () {
 } );
 ```
 
+### `wpgraphql_strava_activities_to_fetch`
+
+Maximum number of activities to fetch from Strava per sync (clamped to 200).
+
+| | |
+|---|---|
+| **Default** | `200` |
+| **Location** | `cache.php` |
+| **Parameter** | `int $count` |
+
+```php
+// Fetch only 50 activities per sync
+add_filter( 'wpgraphql_strava_activities_to_fetch', function () {
+    return 50;
+} );
+```
+
 ## Action Hooks
+
+### `wpgraphql_strava_before_sync`
+
+Fires before activities are fetched from the Strava API.
+
+| | |
+|---|---|
+| **Location** | `cache.php` |
+| **Parameters** | None |
+
+```php
+add_action( 'wpgraphql_strava_before_sync', function () {
+    error_log( 'Strava sync starting...' );
+} );
+```
+
+### `wpgraphql_strava_after_sync`
+
+Fires after activities have been fetched, processed, and cached.
+
+| | |
+|---|---|
+| **Location** | `cache.php` |
+| **Parameters** | `array $activities` (processed), `int $raw_count` (from API) |
+
+```php
+add_action( 'wpgraphql_strava_after_sync', function ( $activities, $raw_count ) {
+    error_log( "Synced $raw_count activities, cached " . count( $activities ) );
+}, 10, 2 );
+```
 
 ### `wpgraphql_strava_cron_refresh`
 
 WordPress cron action that triggers a cache refresh. Scheduled automatically based on the sync frequency setting.
 
 ```php
-// Run something after every sync
+// Run something after every cron sync
 add_action( 'wpgraphql_strava_cron_refresh', function () {
     // Custom post-sync logic
 }, 20 );

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,13 +28,13 @@ Activate in **Plugins** menu.
 
 ## Setup
 
-1. **Create a Strava API application** at [strava.com/settings/api](https://www.strava.com/settings/api)
+1. **Create a Strava API application** at [strava.com/settings/api](https://www.strava.com/settings/api) — set the Authorization Callback Domain to your site's domain
 2. Go to **Strava → Settings** in your WordPress admin
-3. Enter your **Client ID** and **Client Secret**
-4. Generate tokens via the OAuth flow — see [OAuth Setup](oauth-setup.md)
-5. Enter your **Access Token**, **Refresh Token**, and **Token Expires At**
-6. Click **Save Settings**
-7. Click **Resync Activities** to fetch your data
+3. Enter your **Client ID** and **Client Secret**, click **Save Settings**
+4. Click the **"Connect with Strava"** button — this handles the OAuth flow automatically
+5. Your tokens are fetched and activities synced immediately
+
+> **Manual setup**: If you prefer, you can still enter tokens manually — see [OAuth Setup](oauth-setup.md)
 
 ## First Query
 
@@ -58,7 +58,7 @@ You should see your recent activities with inline SVG route maps.
 
 ## Next Steps
 
-- [Activity Fields](fields.md) — full reference of all 21 queryable fields
+- [Activity Fields](fields.md) — full reference of all 22 queryable fields
 - [Admin Settings](settings.md) — configure sync frequency, SVG appearance, and display units
 - [SVG Route Maps](svg-maps.md) — customise route map appearance
 - [Shortcodes](shortcodes.md) — display activities on non-headless WordPress sites

--- a/docs/graphql-queries.md
+++ b/docs/graphql-queries.md
@@ -22,7 +22,8 @@ Returns all cached activities with the requested fields.
 
 | Argument | Type | Default | Description |
 |---|---|---|---|
-| `first` | Int | `0` (all) | Number of activities to return |
+| `first` | Int | `0` (all, max 200) | Number of activities to return |
+| `offset` | Int | `0` | Number of activities to skip (for pagination) |
 | `type` | String | — | Filter by activity type (e.g. `"Ride"`, `"Run"`) |
 
 ## Filtered Query
@@ -36,6 +37,7 @@ Returns all cached activities with the requested fields.
     date
     type
     unit
+    speedUnit
     svgMap
     stravaUrl
     photoUrl
@@ -55,6 +57,22 @@ Returns all cached activities with the requested fields.
 }
 ```
 
+## Pagination with Offset
+
+Use `offset` to paginate through activities:
+
+```graphql
+{
+  stravaActivities(first: 10, offset: 10) {
+    title
+    distance
+    duration
+  }
+}
+```
+
+This returns activities 11-20. Combine with `type` to paginate filtered results.
+
 ## Example Response
 
 ```json
@@ -68,12 +86,13 @@ Returns all cached activities with the requested fields.
         "date": "2026-03-15T08:30:00Z",
         "type": "Ride",
         "unit": "mi",
+        "speedUnit": "mph",
         "svgMap": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 300 200\"...>",
         "stravaUrl": "https://www.strava.com/activities/12345678901",
         "photoUrl": "https://dgtzuqphqg23d.cloudfront.net/...",
         "elevationGain": 312.5,
-        "averageSpeed": 5.56,
-        "maxSpeed": 12.34,
+        "averageSpeed": 12.44,
+        "maxSpeed": 27.6,
         "averageHeartrate": 145.0,
         "maxHeartrate": 172,
         "calories": 580.0,
@@ -88,6 +107,16 @@ Returns all cached activities with the requested fields.
   }
 }
 ```
+
+## REST API
+
+A REST endpoint is also available for non-GraphQL use cases:
+
+```
+GET /wp-json/wpgraphql-strava/v1/activities?count=10&type=Ride&offset=0
+```
+
+Returns the same data structure as the GraphQL query. The `X-WP-Total` header contains the total activity count.
 
 ## Frontend Examples
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,12 +8,17 @@ tests/
 ├── fixtures/
 │   └── strava-api-response.json  # Sample Strava API response
 ├── Unit/
-│   ├── EncryptionTest.php     # AES-256-CBC encrypt/decrypt
-│   ├── PolylineTest.php       # Polyline decoder
-│   └── SvgTest.php            # SVG route map generator
+│   ├── EncryptionTest.php     # AES-256-CBC encrypt/decrypt (8 tests)
+│   ├── PolylineTest.php       # Polyline decoder (4 tests)
+│   └── SvgTest.php            # SVG route map generator (9 tests)
 └── Integration/
-    └── CacheTest.php          # Cache module (processing, distance, photos, duration)
+    ├── ApiTest.php            # Strava API client (11 tests)
+    ├── CacheTest.php          # Cache module (14 tests)
+    ├── GraphQLTest.php        # GraphQL schema & resolver (7 tests)
+    └── ShortcodesTest.php     # Shortcode rendering (12 tests)
 ```
+
+**65 tests total** across 7 test files (21 unit + 44 integration).
 
 ## Running Tests
 

--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,7 @@ GraphQL Strava Activities brings your Strava activities into your headless WordP
         date
         type
         unit
+        speedUnit
         svgMap
         stravaUrl
         photoUrl


### PR DESCRIPTION
## Summary

Updates 8 documentation files to reflect all recent changes, and adds a CI check that catches doc drift going forward.

### Documentation updates
| File | Changes |
|---|---|
| `docs/fields.md` | 21→22 fields, added `speedUnit`, updated speed descriptions to mph/km/h |
| `docs/architecture.md` | Added `oauth.php`, `rest-api.php`, `updater.php` (9→12 files) |
| `docs/graphql-queries.md` | Added `offset` argument, pagination example, REST API section |
| `docs/filters.md` | Added `wpgraphql_strava_activities_to_fetch` filter, `before_sync`/`after_sync` hooks |
| `docs/getting-started.md` | Updated setup to one-click OAuth flow, 22 fields |
| `docs/testing.md` | Updated test structure (4→7 files, 65 tests) |
| `README.md` | New features, `speedUnit` field, new filter, OAuth quick start |
| `readme.txt` | Added `speedUnit` to example query |
| `CLAUDE.md` | Added `activities_to_fetch` filter |

### New CI check: Documentation consistency
Added to the `Validate` job — verifies on every push/PR:
- GraphQL field count in `graphql.php` matches `docs/fields.md` table rows
- Number of PHP files in `includes/` matches `docs/architecture.md` file tree
- Field count in `CLAUDE.md` matches code

If any of these drift, the CI job fails with a specific error message telling you what's out of sync.

## Test plan
- [x] All checks pass (lint, analyse, 65 tests)
- [x] Doc consistency counts verified locally (22 fields, 12 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)