### PR TITLE
fix: split release workflow into PR-based flow for branch protection

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,66 @@
+name: Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create release tag
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Tagging version: $VERSION"
+
+      - name: Verify version matches plugin
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PLUGIN_VERSION=$(grep -oP "Version:\s+\K[0-9.]+" graphql-strava-activities.php)
+
+          if [ "$VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "::error::Branch version ($VERSION) does not match plugin header ($PLUGIN_VERSION)"
+            exit 1
+          fi
+
+      - name: Create and push tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Delete release branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          git push origin --delete "$BRANCH" || true
+
+      - name: Summary
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "### Release ${VERSION} tagged" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Tag \`${VERSION}\` pushed" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Release and deploy workflows will run automatically" >> "$GITHUB_STEP_SUMMARY"
+          echo "- [View releases](https://github.com/${{ github.repository }}/releases)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,10 +15,11 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  release:
-    name: Bump version and tag
+  create-release-pr:
+    name: Create release PR
     runs-on: ubuntu-latest
 
     steps:
@@ -26,12 +27,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Calculate next version
         id: version
@@ -69,47 +69,66 @@ jobs:
             exit 1
           fi
 
+      - name: Create release branch
+        run: |
+          NEXT="${{ steps.version.outputs.next }}"
+          git checkout -b "release/${NEXT}"
+
       - name: Bump version in plugin files
         run: |
           CURRENT="${{ steps.version.outputs.current }}"
           NEXT="${{ steps.version.outputs.next }}"
 
-          # Plugin header.
           sed -i "s/Version:           ${CURRENT}/Version:           ${NEXT}/" graphql-strava-activities.php
-
-          # PHP constant.
           sed -i "s/WPGRAPHQL_STRAVA_VERSION', '${CURRENT}'/WPGRAPHQL_STRAVA_VERSION', '${NEXT}'/" graphql-strava-activities.php
-
-          # readme.txt stable tag.
           sed -i "s/Stable tag: ${CURRENT}/Stable tag: ${NEXT}/" readme.txt
 
       - name: Update changelog
         run: |
           NEXT="${{ steps.version.outputs.next }}"
           DATE=$(date +%Y-%m-%d)
-
-          # Insert new version header after [Unreleased], keep [Unreleased] empty.
           sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [${NEXT}] - ${DATE}/" CHANGELOG.md
 
-      - name: Commit and tag
+      - name: Commit and push branch
         run: |
           NEXT="${{ steps.version.outputs.next }}"
-
           git add graphql-strava-activities.php readme.txt CHANGELOG.md
           git commit -m "chore: bump version to ${NEXT}"
-          git tag "${NEXT}"
+          git push origin "release/${NEXT}"
 
-      - name: Push
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           NEXT="${{ steps.version.outputs.next }}"
-          git push origin main
-          git push origin "${NEXT}"
+          CURRENT="${{ steps.version.outputs.current }}"
+
+          gh pr create \
+            --title "chore: release ${NEXT}" \
+            --body "$(cat <<EOF
+          ## Release ${NEXT}
+
+          Automated version bump: ${CURRENT} → ${NEXT} (${{ inputs.bump_type }})
+
+          ### Changes
+          $(sed -n '/^## \[Unreleased\]/,/^## \['"${NEXT}"'\]/{ /^## \[/d; /^$/d; p; }' CHANGELOG.md)
+
+          ### Checklist
+          - [ ] CI passes
+          - [ ] Changelog looks correct
+          - [ ] Ready to release
+
+          > Merging this PR will automatically create the \`${NEXT}\` tag and trigger the GitHub Release and WordPress.org deploy workflows.
+          EOF
+          )" \
+            --label "release" \
+            --head "release/${NEXT}" \
+            --base main
 
       - name: Summary
         run: |
           NEXT="${{ steps.version.outputs.next }}"
-          echo "### Release ${NEXT} 🚀" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Release PR created for ${NEXT}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Version bumped: ${{ steps.version.outputs.current }} → ${NEXT}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Tag \`${NEXT}\` pushed — release and deploy workflows will run automatically" >> "$GITHUB_STEP_SUMMARY"
-          echo "- [View releases](https://github.com/${{ github.repository }}/releases)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch: \`release/${NEXT}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Review and merge the PR to trigger the release" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

The original `version-bump.yml` failed because branch protection requires PRs and signed commits. Direct push to main was rejected.

## Solution

Split into two workflows that respect branch protection:

### Flow
```
Actions → Release Version → pick bump type
    ↓
version-bump.yml creates release/X.Y.Z branch + opens PR
    ↓
Code owner reviews and merges PR (CI must pass)
    ↓
tag-release.yml detects merged release/* PR → creates tag
    ↓
release.yml builds zip + deploy.yml pushes to WP.org (existing)
```

### version-bump.yml (manual trigger)
- Calculates next version from bump type
- Verifies CHANGELOG.md has unreleased entries
- Creates `release/X.Y.Z` branch with version bump
- Opens PR with changelog summary and review checklist

### tag-release.yml (on PR merge)
- Fires when a `release/*` PR is merged to main
- Verifies plugin header version matches branch name
- Creates and pushes the git tag
- Cleans up the release branch

## Test plan
- [x] Local checks pass
- [ ] Trigger Release Version workflow after merge to verify full flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)