### PR TITLE
fix: clean up stale release branch on retry

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -69,6 +69,11 @@ jobs:
             exit 1
           fi
 
+      - name: Clean up stale release branch
+        run: |
+          NEXT="${{ steps.version.outputs.next }}"
+          git push origin --delete "release/${NEXT}" 2>/dev/null || true
+
       - name: Create release branch
         run: |
           NEXT="${{ steps.version.outputs.next }}"


### PR DESCRIPTION
Adds a cleanup step to `version-bump.yml` that deletes any leftover `release/*` branch from a previous failed run before creating the new one. Prevents non-fast-forward push errors on retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)