### PR TITLE
fix: use RELEASE_PAT for version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Configure git
         run: |
@@ -103,7 +104,7 @@ jobs:
 
       - name: Create pull request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           NEXT="${{ steps.version.outputs.next }}"
           CURRENT="${{ steps.version.outputs.current }}"


### PR DESCRIPTION
GITHUB_TOKEN doesn't trigger workflows on branches it creates (GitHub security feature to prevent loops). Swaps to the fine-grained `RELEASE_PAT` secret for checkout and PR creation so CI runs on release PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)