### PR TITLE
fix: use RELEASE_PAT in tag-release workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Configure git
         run: |


### PR DESCRIPTION
Same issue as #116 — tags pushed by `GITHUB_TOKEN` don't trigger other workflows. The `release.yml` and `deploy.yml` workflows never fired for 1.0.4 because the tag was pushed with `GITHUB_TOKEN`.

Swaps to `RELEASE_PAT` in the checkout step so the tag push triggers downstream workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)