### PR TITLE
feat: reset to 0.1.0 as first official release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
   security-events: write
@@ -73,7 +76,7 @@ jobs:
           '
 
       - name: Upload PHPCS SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: phpcs-results.sarif
@@ -114,7 +117,7 @@ jobs:
           '
 
       - name: Upload PHPStan SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: phpstan-results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,110 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- Release workflow uses RELEASE_PAT so CI runs on release PRs and tags trigger downstream workflows
-- Stale release branch cleanup on workflow retry
+## [0.1.0] - 2026-03-15
 
-## [1.0.4] - 2026-03-15
+Initial public release.
 
 ### Added
-- One-click "Connect with Strava" OAuth flow — eliminates manual curl token exchange
-- OAuth callback handler with CSRF protection via state nonce
-- Automatic first sync after successful OAuth authorization
-- "Test Connection" button on Settings page — verifies credentials and shows athlete name
-- Connection Status card on Settings page with token expiry date and status indicator
-- Token health admin notice on plugin pages when credentials are missing or expired
-- Specific API error descriptions (401, 403, 429, 5xx) replacing generic "API returned status" messages
-- `offset` argument for GraphQL `stravaActivities` query for pagination
-- `speedUnit` GraphQL field ("mph" or "km/h") matching the distance unit setting
-- Speed fields (`averageSpeed`, `maxSpeed`) now converted to match distance unit (mph or km/h)
-- `wpgraphql_strava_before_sync` and `wpgraphql_strava_after_sync` action hooks
-- `wpgraphql_strava_activities_to_fetch` filter (default 200, max 200)
-- Copy-to-clipboard buttons on GraphQL query examples in Getting Started page
-- Input validation: `first` clamped to 0-200, `offset` validated, `type` sanitized
-- REST API endpoint: `GET /wp-json/wpgraphql-strava/v1/activities` with `count`, `offset`, `type` params
-- SVG route thumbnails in admin Activities list table (replaces checkmarks)
-- Plugin Check (PCP) job in CI workflow
-- GitHub topics for repository discoverability
-- Shortcode generator button in the classic editor ("Strava" button next to "Add Media")
-- CI validation gates: version consistency check, distribution archive check, text domain check
-- Plugin Check (PCP) now fails CI on errors (was output-only)
-- Security CI job: `composer audit`, debug code detection, hardcoded secret scanning, unsafe PHP function detection
-- PHPCS and PHPStan results uploaded to GitHub Code Scanning via SARIF
-- Automated release workflow — code owners run `Release Version` from Actions tab (patch/minor/major)
-- Dependency Review on PRs (fails on high-severity vulnerabilities)
-
-## [1.0.3] - 2026-03-15
-
-### Changed
-- Version bump to test self-hosted update checker
-
-## [1.0.2] - 2026-03-15
-
-### Added
-- Self-hosted update checker — manually-installed copies receive update notifications via GitHub Releases API
-- Integration tests for API client (11 tests: token refresh, error handling, 401 retry)
-- Integration tests for GraphQL schema (7 tests: type registration, resolver, filtering)
-- Integration tests for shortcodes (12 tests: all 5 shortcodes, card rendering)
-- `wpgraphql_strava_allowed_svg_tags()` helper for explicit SVG output escaping
-- WordPress.org placeholder banner and icon SVG assets
-
-### Fixed
-- Added nonce verification to Activities list table filter form
-- Whitelisted sort parameters in list table to prevent arbitrary key access
-- Replaced `phpcs:ignore` SVG output with `wp_kses()` and explicit tag allowlist
-
-## [1.0.1] - 2026-03-15
-
-### Fixed
-- Replaced `error_log()` calls in API client with `wp_trigger_error()` for production use
-- Replaced `strip_tags()` in test mock with `wp_strip_all_tags()` for WPCS compliance
-- Renamed `GRAPHQL_STRAVA_ENCRYPTION_KEY` constant to `WPGRAPHQL_STRAVA_ENCRYPTION_KEY` to match plugin prefix convention
-- Added `phpcs:ignore` comments on WPGraphQL stub functions (must match upstream names)
-- Added `.phpunit.result.cache` to `.distignore`
-- Updated "Tested up to" to WordPress 6.9
-
-### Changed
-- GitHub Pages documentation site with Docsify (user guide + developer guide)
-- Updated readme.txt sync frequency description and GraphQL example to include all 21 fields
-- Added `composer analyse` command to CLAUDE.md
-- Added `poweredByStrava` field to README.md GraphQL example
-
-### Added
-- Weekly, every 2 weeks, and monthly sync frequency options
-- "Powered by Strava" attribution in admin footer and brand attribution docs on Getting Started page
-- `poweredByStrava` GraphQL field for frontend attribution compliance
-- Strava brand-compliant orange (#FC5200) styling on admin "View on Strava" links
-- Official "Connect with Strava" button SVG on Getting Started page
-- PHPUnit test suite with unit and integration tests
-- Unit tests for polyline decoder, encryption, and SVG generator
-- Integration tests for cache module (duration formatting, activity processing, distance conversion)
-- GitHub Actions CI workflow — PHP 8.0-8.3 matrix with lint + test on every push/PR
-- `composer test`, `composer test:unit`, `composer test:integration` scripts
-- GrumPHP pre-commit hooks — lint and tests run automatically on every commit
-- SUPPORT.md with help channels and in-plugin docs reference
-- Getting Started is now the default page when clicking "Strava" in admin
-- Settings moved to Strava → Settings submenu
-- Setting to include activities without GPS routes (indoor, treadmill, yoga)
-- PHPStan level 5 static analysis with WordPress extension
-- `composer analyse` script and PHPStan in GrumPHP pre-commit
-- GitHub Release automation — creates release with zip on tag push
-- Repo topics, discussion categories, required PR approvals
-- Sample Strava API response fixture for test mocking
-
-## [1.0.0] - 2026-03-15
-
-### Added
-- Plugin bootstrap with WPGraphQL dependency check and cron scheduling
-- Strava API client with OAuth token refresh and rate limiting
-- Transient caching with configurable TTL and photo enrichment
-- Google polyline decoder and server-side SVG route map generator
-- WPGraphQL schema: StravaActivity type and stravaActivities query with type filter
-- Admin settings page: credentials, SVG customization, display units, sync frequency
-- Getting Started documentation page with setup guide and code examples
-- Preview page with live activity cards and demo data
-- Optional AES-256-CBC at-rest credential encryption
-- WordPress.org readme.txt with Third-Party Service disclosure
-- GitHub Actions workflow for WordPress.org SVN deployment
-- Dependabot for Composer and GitHub Actions updates
-- WPCS 3.0 linting via composer lint
+- **GraphQL API** — `StravaActivity` type with 22 fields, `stravaActivities` query with `first`, `offset`, and `type` arguments
+- **REST API** — `GET /wp-json/wpgraphql-strava/v1/activities` endpoint with `count`, `offset`, `type` params
+- **Server-side SVG route maps** — inline SVG generation from Google encoded polylines, no JavaScript required
+- **One-click OAuth** — "Connect with Strava" button with automatic token exchange and CSRF protection
+- **Strava API client** — activity fetching, detail enrichment, automatic OAuth token refresh, rate limiting
+- **Transient caching** — configurable TTL with 11 sync frequency options (15 min to monthly)
+- **Admin settings** — credentials, SVG customization (color, stroke width), display units, sync controls
+- **Connection status** — token expiry monitoring, Test Connection button, health notices
+- **Activity photos** — primary photo fetching and enrichment for top 5 activities
+- **Shortcodes** — 5 shortcodes (`strava_activities`, `strava_activity`, `strava_map`, `strava_stats`, `strava_latest`) with classic editor generator button
+- **Credential encryption** — optional AES-256-CBC at-rest encryption via `WPGRAPHQL_STRAVA_ENCRYPTION_KEY`
+- **Self-hosted updater** — GitHub Releases API update checker for manually-installed copies
+- **Speed conversion** — `averageSpeed` and `maxSpeed` converted to mph/km/h matching distance unit, `speedUnit` field
+- **Extensibility** — filters for cache TTL, SVG appearance, activity types, fetch count; `before_sync`/`after_sync` action hooks
+- **Security** — `wp_kses` SVG output with explicit tag allowlist, nonce verification, input validation, capability checks
+- **65 automated tests** — unit tests (encryption, polyline, SVG) and integration tests (API, cache, GraphQL, shortcodes)
+- **CI pipeline** — PHPCS, PHPStan level 5, PHPUnit, Plugin Check, security scanning, SARIF code scanning, dependency review
+- **Automated releases** — version bump workflow with PR-based flow, tag-on-merge, GitHub Release + WP.org deploy
+- **Documentation** — Docsify site, Getting Started guide, field reference, filter docs, architecture docs

--- a/graphql-strava-activities.php
+++ b/graphql-strava-activities.php
@@ -3,7 +3,7 @@
  * Plugin Name:       GraphQL Strava Activities
  * Plugin URI:        https://github.com/shawnazar/graphql-strava-activities
  * Description:       Compatible with Strava — extends WPGraphQL with activity data, server-side SVG route maps, and photos.
- * Version:           1.0.4
+ * Version:           0.1.0
  * Requires at least: 6.0
  * Requires PHP:      8.2
  * Requires Plugins:  wp-graphql
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-define( 'WPGRAPHQL_STRAVA_VERSION', '1.0.4' );
+define( 'WPGRAPHQL_STRAVA_VERSION', '0.1.0' );
 
 /**
  * Plugin root directory path.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 6.0
 Tested up to: 6.9
 Requires PHP: 8.2
 Requires Plugins: wp-graphql
-Stable tag: 1.0.4
+Stable tag: 0.1.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -120,37 +120,30 @@ Yes. Any frontend that can query WPGraphQL (Next.js, Gatsby, Astro, etc.) will w
 
 == Changelog ==
 
-= 1.0.2 =
-* Added: Self-hosted update checker — manually-installed copies receive update notifications via GitHub Releases.
-* Added: Nonce verification on Activities list table filter form.
-* Added: wp_kses SVG escaping with explicit tag allowlist replacing phpcs:ignore comments.
-* Added: 30 new integration tests (65 total) for API client, GraphQL schema, and shortcodes.
-* Added: Placeholder banner and icon SVG assets for WordPress.org.
-* Added: Whitelisted sort parameters in list table to prevent arbitrary key access.
-
-= 1.0.1 =
-* Fixed: Replaced error_log() with wp_trigger_error() for production use.
-* Fixed: Renamed GRAPHQL_STRAVA_ENCRYPTION_KEY to WPGRAPHQL_STRAVA_ENCRYPTION_KEY for prefix consistency.
-* Fixed: Replaced strip_tags() with wp_strip_all_tags() in test mocks.
-* Fixed: Updated "Tested up to" to WordPress 6.9.
-
-= 1.0.0 =
-* Initial release.
-* GraphQL schema with StravaActivity type and stravaActivities query.
+= 0.1.0 =
+* Initial public release.
+* GraphQL API — StravaActivity type with 22 fields, stravaActivities query with first/offset/type arguments.
+* REST API — GET /wp-json/wpgraphql-strava/v1/activities endpoint.
 * Server-side SVG route map generation from encoded polylines.
-* Strava API client with OAuth token refresh.
-* Transient caching with configurable TTL.
-* Admin settings page for credentials, SVG customization, display options, and sync.
-* Activity photo fetching.
-* Extensible via WordPress filters and hooks.
+* One-click "Connect with Strava" OAuth flow with automatic token exchange.
+* Strava API client with automatic OAuth token refresh.
+* Transient caching with configurable TTL and 11 sync frequency options.
+* Admin settings page with credential management, SVG customization, and sync controls.
+* Connection status card with token expiry monitoring and Test Connection button.
+* Token health admin notices for expired or missing credentials.
+* Activity photo fetching and enrichment.
+* Shortcode generator button in the classic editor.
+* Five WordPress shortcodes for non-headless sites.
+* Optional AES-256-CBC at-rest credential encryption.
+* Self-hosted update checker via GitHub Releases API.
+* wp_kses SVG escaping with explicit tag allowlist.
+* Pre/post sync action hooks for extensibility.
+* Speed fields converted to mph/km/h matching distance unit setting.
+* 65 automated tests across 7 test files.
+* CI pipeline with PHPCS, PHPStan, Plugin Check, security scanning, and SARIF code scanning.
+* Automated release workflow with version bump and changelog management.
 
 == Upgrade Notice ==
 
-= 1.0.2 =
-Adds automatic update notifications for GitHub-installed copies. Security and test improvements.
-
-= 1.0.1 =
-Breaking: If you use credential encryption, rename GRAPHQL_STRAVA_ENCRYPTION_KEY to WPGRAPHQL_STRAVA_ENCRYPTION_KEY in wp-config.php.
-
-= 1.0.0 =
-Initial release.
+= 0.1.0 =
+Initial public release.


### PR DESCRIPTION
## Summary

Resets the plugin to version **0.1.0** as the first official public release, consolidates all changelog entries, and upgrades CI dependencies.

### Version reset (#119)
- Plugin header, constant, and readme.txt Stable tag all set to `0.1.0`
- CHANGELOG.md rewritten with a single consolidated `[0.1.0]` entry covering all features

### CI upgrades (#121, #122)
- `github/codeql-action/upload-sarif` upgraded from v3 to v4
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env var added

### Next step after merge
- Delete old releases and tags (1.0.1–1.0.4) per #120
- Tag `0.1.0` and create the first official GitHub Release

Closes #119, #121, #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)