### PR TITLE
feat: multi-athlete support and GraphQL subscription infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - React component examples (`examples/react/`) — StravaActivities, StravaMap, StravaStats
 - Next.js starter example (`examples/nextjs/`) — App Router page with ISR
 - Astro example (`examples/astro/`) — static site generation, zero client JS
+- Multi-athlete support: `userId` argument on GraphQL and REST API, per-user credentials via user meta
+- `wpgraphql_strava_get_user_activities()` and `wpgraphql_strava_get_user_option()` functions
+- GraphQL subscription infrastructure: `stravaLastEvent` query field, `StravaEvent` type, event publishing on webhooks
+- `wpgraphql_strava_subscription_event` action hook for external subscription systems
 
 ## [0.1.3] - 2026-03-16
 

--- a/includes/cache.php
+++ b/includes/cache.php
@@ -111,6 +111,49 @@ function wpgraphql_strava_cache_delete( string $key ): bool {
 }
 
 /**
+ * Get cached Strava activities for a specific user.
+ *
+ * When $user_id is 0 (default), uses the global plugin credentials.
+ * When a user ID is provided, uses that user's per-user credentials.
+ *
+ * @param int $count   Number of activities to return (0 = all cached).
+ * @param int $user_id WordPress user ID (0 = global/default).
+ * @return array<int, array<string, mixed>> Processed activity data.
+ */
+function wpgraphql_strava_get_user_activities( int $count = 0, int $user_id = 0 ): array {
+	if ( 0 === $user_id ) {
+		return wpgraphql_strava_get_cached_activities( $count );
+	}
+
+	$cache_key = WPGRAPHQL_STRAVA_CACHE_KEY . '_user_' . $user_id;
+	$cached    = wpgraphql_strava_cache_get( $cache_key );
+
+	if ( is_array( $cached ) && count( $cached ) > 0 ) {
+		return $count > 0 ? array_slice( $cached, 0, $count ) : $cached;
+	}
+
+	$access_token = wpgraphql_strava_get_user_option( $user_id, 'wpgraphql_strava_access_token' );
+
+	if ( empty( $access_token ) ) {
+		return [];
+	}
+
+	$fetch_count    = min( (int) apply_filters( 'wpgraphql_strava_activities_to_fetch', 200 ), 200 );
+	$raw_activities = wpgraphql_strava_fetch_activities_with_token( $access_token, $fetch_count );
+
+	if ( empty( $raw_activities ) ) {
+		return [];
+	}
+
+	$activities = wpgraphql_strava_process_activities( $raw_activities );
+	$ttl        = (int) apply_filters( 'wpgraphql_strava_cache_ttl', WPGRAPHQL_STRAVA_CACHE_TTL );
+
+	wpgraphql_strava_cache_set( $cache_key, $activities, $ttl );
+
+	return $count > 0 ? array_slice( $activities, 0, $count ) : $activities;
+}
+
+/**
  * Get cached Strava activities, fetching fresh data when the cache is empty.
  *
  * Always requests the maximum from the API (200) and caches the full set.

--- a/includes/encryption.php
+++ b/includes/encryption.php
@@ -162,3 +162,43 @@ function wpgraphql_strava_update_option( string $option, string $value ): bool {
 
 	return update_option( $option, $value );
 }
+
+/**
+ * Get a sensitive user meta value, decrypting if necessary.
+ *
+ * Used for multi-athlete support where each user has their own credentials.
+ *
+ * @param int    $user_id User ID.
+ * @param string $key     Meta key (without user prefix).
+ * @param string $default Default value.
+ * @return string Decrypted value.
+ */
+function wpgraphql_strava_get_user_option( int $user_id, string $key, string $default = '' ): string {
+	$value = get_user_meta( $user_id, $key, true );
+
+	if ( ! is_string( $value ) || empty( $value ) ) {
+		return $default;
+	}
+
+	if ( in_array( $key, WPGRAPHQL_STRAVA_ENCRYPTED_OPTIONS, true ) ) {
+		return wpgraphql_strava_decrypt( $value );
+	}
+
+	return $value;
+}
+
+/**
+ * Save a sensitive user meta value, encrypting if configured.
+ *
+ * @param int    $user_id User ID.
+ * @param string $key     Meta key.
+ * @param string $value   Plain-text value.
+ * @return bool True on success.
+ */
+function wpgraphql_strava_update_user_option( int $user_id, string $key, string $value ): bool {
+	if ( in_array( $key, WPGRAPHQL_STRAVA_ENCRYPTED_OPTIONS, true ) ) {
+		$value = wpgraphql_strava_encrypt( $value );
+	}
+
+	return (bool) update_user_meta( $user_id, $key, $value );
+}

--- a/includes/graphql.php
+++ b/includes/graphql.php
@@ -144,14 +144,20 @@ function wpgraphql_strava_register_types(): void {
 					'type'        => 'String',
 					'description' => __( 'Filter by activity type (e.g. "Ride", "Run").', 'graphql-strava-activities' ),
 				],
+				'userId' => [
+					'type'         => 'Int',
+					'description'  => __( 'WordPress user ID for multi-athlete support (0 = global default).', 'graphql-strava-activities' ),
+					'defaultValue' => 0,
+				],
 			],
 			'resolve'     => static function ( $root, array $args ): array {
 				// Validate and clamp arguments.
-				$count  = min( max( (int) ( $args['first'] ?? 0 ), 0 ), 200 );
-				$offset = max( (int) ( $args['offset'] ?? 0 ), 0 );
+				$count   = min( max( (int) ( $args['first'] ?? 0 ), 0 ), 200 );
+				$offset  = max( (int) ( $args['offset'] ?? 0 ), 0 );
+				$user_id = max( (int) ( $args['userId'] ?? 0 ), 0 );
 
-				// Fetch all cached activities (filtering/slicing done below).
-				$activities = wpgraphql_strava_get_cached_activities( 0 );
+				// Fetch activities (user-specific or global).
+				$activities = wpgraphql_strava_get_user_activities( 0, $user_id );
 
 				// Type filter.
 				$type_filter = sanitize_text_field( $args['type'] ?? '' );
@@ -171,6 +177,41 @@ function wpgraphql_strava_register_types(): void {
 
 				return $activities;
 			},
+		]
+	);
+
+	// Subscription-ready event polling field.
+	register_graphql_field(
+		'RootQuery',
+		'stravaLastEvent',
+		[
+			'type'        => 'StravaEvent',
+			'description' => __( 'Latest Strava webhook event (for polling-based subscriptions).', 'graphql-strava-activities' ),
+			'resolve'     => static function (): ?array {
+				$event = get_transient( 'wpgraphql_strava_last_event' );
+				return is_array( $event ) ? $event : null;
+			},
+		]
+	);
+
+	register_graphql_object_type(
+		'StravaEvent',
+		[
+			'description' => __( 'A Strava webhook event.', 'graphql-strava-activities' ),
+			'fields'      => [
+				'type'       => [
+					'type'        => 'String',
+					'description' => __( 'Event type: create, update, or delete.', 'graphql-strava-activities' ),
+				],
+				'activityId' => [
+					'type'        => 'Int',
+					'description' => __( 'Strava activity ID.', 'graphql-strava-activities' ),
+				],
+				'timestamp'  => [
+					'type'        => 'Int',
+					'description' => __( 'Unix timestamp of the event.', 'graphql-strava-activities' ),
+				],
+			],
 		]
 	);
 }

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -43,10 +43,16 @@ function wpgraphql_strava_register_rest_routes(): void {
 					'minimum'           => 0,
 					'sanitize_callback' => 'absint',
 				],
-				'type'   => [
+				'type'    => [
 					'type'              => 'string',
 					'default'           => '',
 					'sanitize_callback' => 'sanitize_text_field',
+				],
+				'user_id' => [
+					'type'              => 'integer',
+					'default'           => 0,
+					'minimum'           => 0,
+					'sanitize_callback' => 'absint',
 				],
 			],
 		]
@@ -63,7 +69,8 @@ function wpgraphql_strava_rest_activities( \WP_REST_Request $request ): \WP_REST
 	$count      = (int) $request->get_param( 'count' );
 	$offset     = (int) $request->get_param( 'offset' );
 	$type       = (string) $request->get_param( 'type' );
-	$activities = wpgraphql_strava_get_cached_activities( 0 );
+	$user_id    = (int) $request->get_param( 'user_id' );
+	$activities = wpgraphql_strava_get_user_activities( 0, $user_id );
 
 	// Type filter.
 	if ( ! empty( $type ) ) {

--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -119,8 +119,44 @@ function wpgraphql_strava_webhook_event( \WP_REST_Request $request ): \WP_REST_R
 		 * @param array<string, mixed> $body Full webhook payload.
 		 */
 		do_action( 'wpgraphql_strava_webhook_event', $aspect_type, $body );
+
+		// Publish event for GraphQL subscription consumers.
+		wpgraphql_strava_publish_subscription_event( $aspect_type, $object_id );
 	}
 
 	// Strava requires a 200 response within 2 seconds.
 	return new \WP_REST_Response( [ 'status' => 'ok' ], 200 );
+}
+
+/**
+ * Publish a subscription event for GraphQL consumers.
+ *
+ * Stores the latest activity event in a transient so subscription
+ * resolvers or polling clients can detect changes. When WPGraphQL
+ * adds native subscription support, this can be extended to push
+ * events directly.
+ *
+ * @param string $event_type create, update, or delete.
+ * @param int    $activity_id Strava activity ID.
+ * @return void
+ */
+function wpgraphql_strava_publish_subscription_event( string $event_type, int $activity_id ): void {
+	$event = [
+		'type'        => $event_type,
+		'activityId'  => $activity_id,
+		'timestamp'   => time(),
+	];
+
+	set_transient( 'wpgraphql_strava_last_event', $event, HOUR_IN_SECONDS );
+
+	/**
+	 * Fires when a subscription event is published.
+	 *
+	 * Developers can hook into this to push events to external
+	 * subscription systems (e.g. Pusher, Mercure, or a custom
+	 * WebSocket server).
+	 *
+	 * @param array<string, mixed> $event Event data.
+	 */
+	do_action( 'wpgraphql_strava_subscription_event', $event );
 }

--- a/tests/Integration/GraphQLTest.php
+++ b/tests/Integration/GraphQLTest.php
@@ -32,39 +32,18 @@ class GraphQLTest extends TestCase {
 	private array $options = [];
 
 	/**
-	 * Captured config for register_graphql_object_type.
+	 * All captured object types by name.
 	 *
-	 * @var array<string, mixed>|null
+	 * @var array<string, array<string, mixed>>
 	 */
-	private ?array $captured_object_type_config = null;
+	private array $captured_types = [];
 
 	/**
-	 * Captured name for register_graphql_object_type.
+	 * All captured fields by "type.field" key.
 	 *
-	 * @var string|null
+	 * @var array<string, array<string, mixed>>
 	 */
-	private ?string $captured_object_type_name = null;
-
-	/**
-	 * Captured arguments for register_graphql_field.
-	 *
-	 * @var array<string, mixed>|null
-	 */
-	private ?array $captured_field_config = null;
-
-	/**
-	 * Captured type name for register_graphql_field.
-	 *
-	 * @var string|null
-	 */
-	private ?string $captured_field_type_name = null;
-
-	/**
-	 * Captured field name for register_graphql_field.
-	 *
-	 * @var string|null
-	 */
-	private ?string $captured_field_name = null;
+	private array $captured_fields = [];
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -78,11 +57,8 @@ class GraphQLTest extends TestCase {
 			'wpgraphql_strava_svg_stroke_width' => 2.5,
 		];
 
-		$this->captured_object_type_config = null;
-		$this->captured_object_type_name   = null;
-		$this->captured_field_config       = null;
-		$this->captured_field_type_name    = null;
-		$this->captured_field_name         = null;
+		$this->captured_types  = [];
+		$this->captured_fields = [];
 
 		Functions\stubTranslationFunctions();
 
@@ -145,16 +121,13 @@ class GraphQLTest extends TestCase {
 
 		Functions\when( 'register_graphql_object_type' )->alias(
 			function ( string $type_name, array $config ): void {
-				$this->captured_object_type_name   = $type_name;
-				$this->captured_object_type_config = $config;
+				$this->captured_types[ $type_name ] = $config;
 			}
 		);
 
 		Functions\when( 'register_graphql_field' )->alias(
 			function ( string $type_name, string $field_name, array $config ): void {
-				$this->captured_field_type_name = $type_name;
-				$this->captured_field_name      = $field_name;
-				$this->captured_field_config    = $config;
+				$this->captured_fields[ $type_name . '.' . $field_name ] = $config;
 			}
 		);
 
@@ -184,9 +157,10 @@ class GraphQLTest extends TestCase {
 	 */
 	private function register_and_get_resolver(): callable {
 		wpgraphql_strava_register_types();
-		$this->assertNotNull( $this->captured_field_config, 'register_graphql_field was not called.' );
-		$this->assertArrayHasKey( 'resolve', $this->captured_field_config );
-		return $this->captured_field_config['resolve'];
+		$key = 'RootQuery.stravaActivities';
+		$this->assertArrayHasKey( $key, $this->captured_fields, 'register_graphql_field was not called for stravaActivities.' );
+		$this->assertArrayHasKey( 'resolve', $this->captured_fields[ $key ] );
+		return $this->captured_fields[ $key ]['resolve'];
 	}
 
 	/**
@@ -294,11 +268,12 @@ class GraphQLTest extends TestCase {
 	public function test_register_types_registers_strava_activity_type(): void {
 		wpgraphql_strava_register_types();
 
-		$this->assertSame( 'StravaActivity', $this->captured_object_type_name );
-		$this->assertArrayHasKey( 'description', $this->captured_object_type_config );
-		$this->assertArrayHasKey( 'fields', $this->captured_object_type_config );
+		$this->assertArrayHasKey( 'StravaActivity', $this->captured_types );
+		$config = $this->captured_types['StravaActivity'];
+		$this->assertArrayHasKey( 'description', $config );
+		$this->assertArrayHasKey( 'fields', $config );
 
-		$fields = $this->captured_object_type_config['fields'];
+		$fields = $config['fields'];
 
 		$expected_fields = [
 			'title',
@@ -338,14 +313,16 @@ class GraphQLTest extends TestCase {
 	public function test_register_types_registers_root_query_field(): void {
 		wpgraphql_strava_register_types();
 
-		$this->assertSame( 'RootQuery', $this->captured_field_type_name );
-		$this->assertSame( 'stravaActivities', $this->captured_field_name );
-		$this->assertArrayHasKey( 'type', $this->captured_field_config );
-		$this->assertArrayHasKey( 'description', $this->captured_field_config );
-		$this->assertArrayHasKey( 'args', $this->captured_field_config );
-		$this->assertArrayHasKey( 'resolve', $this->captured_field_config );
-		$this->assertArrayHasKey( 'first', $this->captured_field_config['args'] );
-		$this->assertArrayHasKey( 'type', $this->captured_field_config['args'] );
+		$key = 'RootQuery.stravaActivities';
+		$this->assertArrayHasKey( $key, $this->captured_fields );
+		$config = $this->captured_fields[ $key ];
+		$this->assertArrayHasKey( 'type', $config );
+		$this->assertArrayHasKey( 'description', $config );
+		$this->assertArrayHasKey( 'args', $config );
+		$this->assertArrayHasKey( 'resolve', $config );
+		$this->assertArrayHasKey( 'first', $config['args'] );
+		$this->assertArrayHasKey( 'type', $config['args'] );
+		$this->assertArrayHasKey( 'userId', $config['args'] );
 	}
 
 	public function test_resolver_returns_all_cached_activities(): void {


### PR DESCRIPTION
## Summary

### #156 — Multi-athlete support
- `userId` argument on `stravaActivities` GraphQL query and REST API endpoint
- Per-user credentials stored in `user_meta` via `wpgraphql_strava_get_user_option()` / `wpgraphql_strava_update_user_option()`
- Per-user cache keys (`wpgraphql_strava_activities_user_N`)
- Backward compatible: `userId=0` (default) uses global plugin credentials

### #154 — GraphQL subscription infrastructure
- `stravaLastEvent` query field — returns latest webhook event for polling
- `StravaEvent` GraphQL type with `type`, `activityId`, `timestamp` fields
- Event publishing on webhook events stored in transient
- `wpgraphql_strava_subscription_event` action hook for external subscription systems (Pusher, Mercure, WebSocket)

## Test plan
- [x] Lint, analyse, 65 tests pass
- [x] GraphQL test updated for multi-capture of types/fields

Closes #154, #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)