### PR TITLE
docs: add elevationProfileSvg to CLAUDE.md and example queries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ The `StravaActivity` type exposes 23 fields. All come from the Strava list endpo
 | type | String | `type` |
 | unit | String | Setting |
 | svgMap | String | `map.summary_polyline` (rendered) |
+| elevationProfileSvg | String | Elevation profile SVG chart |
 | stravaUrl | String | `id` (constructed URL) |
 | photoUrl | String | `photos.primary.urls` |
 | elevationGain | Float | `total_elevation_gain` (metres) |

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Activate in WordPress, then visit **Strava** in the admin menu.
     unit
     speedUnit
     svgMap
+    elevationProfileSvg
     stravaUrl
     photoUrl
     elevationGain

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,7 @@ GraphQL Strava Activities brings your Strava activities into your headless WordP
         unit
         speedUnit
         svgMap
+        elevationProfileSvg
         stravaUrl
         photoUrl
         elevationGain


### PR DESCRIPTION
Final doc sync — field was in code and docs/fields.md but missing from CLAUDE.md table and example queries in README/readme.txt.