### PR TITLE
chore: release 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-03-17
+
 ### Added
 - `.pot` file generation via `composer make-pot` for internationalization
 - `wp strava sync` and `wp strava status` WP-CLI commands

--- a/graphql-strava-activities.php
+++ b/graphql-strava-activities.php
@@ -3,7 +3,7 @@
  * Plugin Name:       GraphQL Strava Activities
  * Plugin URI:        https://github.com/shawnazar/graphql-strava-activities
  * Description:       Compatible with Strava — extends WPGraphQL with activity data, server-side SVG route maps, and photos.
- * Version:           0.1.3
+ * Version:           0.1.4
  * Requires at least: 6.0
  * Requires PHP:      8.2
  * Requires Plugins:  wp-graphql
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-define( 'WPGRAPHQL_STRAVA_VERSION', '0.1.3' );
+define( 'WPGRAPHQL_STRAVA_VERSION', '0.1.4' );
 
 /**
  * Plugin root directory path.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 6.0
 Tested up to: 6.9
 Requires PHP: 8.2
 Requires Plugins: wp-graphql
-Stable tag: 0.1.3
+Stable tag: 0.1.4
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 


### PR DESCRIPTION
## Release 0.1.4

Automated version bump: 0.1.3 → 0.1.4 (patch)

### Changes


### Checklist
- [ ] CI passes
- [ ] Changelog looks correct
- [ ] Ready to release

> Merging this PR will automatically create the `0.1.4` tag and trigger the GitHub Release and WordPress.org deploy workflows.